### PR TITLE
Intacct Lava Memo Field

### DIFF
--- a/Intacct/BatchToJournal.ascx
+++ b/Intacct/BatchToJournal.ascx
@@ -5,5 +5,6 @@
         <asp:Literal runat="server" ID="litDateExported" Visible="false"></asp:Literal>
         <Rock:BootstrapButton runat="server" Visible="false" ID="btnRemoveDate" Text="Remove Date Exported" OnClick="btnRemoveDateExported_Click" CssClass="btn btn-link" />
         <Rock:BootstrapButton runat="server" Visible="false" ID="btnExportToIntacct" OnClick="btnExportToIntacct_Click" CssClass="btn btn-primary" />
+        <asp:Literal ID="lDebug" runat="server" Visible="false" />
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/Intacct/BatchToJournal.ascx.cs
+++ b/Intacct/BatchToJournal.ascx.cs
@@ -49,7 +49,7 @@ namespace RockWeb.Plugins.rocks_kfs.Intacct
     [EncryptedTextField( "User Id", "The Intacct User Id. This is the same information you use when you log into the Sage Intacct UI.", true, "", "Configuration", 3 )]
     [EncryptedTextField( "User Password", "The Intacct User Password. This is the same information you use when you log into the Sage Intacct UI.", true, "", "Configuration", 4 )]
     [EncryptedTextField( "Location Id", "The optional Intacct Location Id. Add a location ID to log into a multi-entity shared company. Entities are typically different locations of a single company.", false, "", "Configuration", 5 )]
-    [LavaField( "Journal Description Lava", "Lava for the journal memo per line. Default: Batch.Id: Batch.Name", true, "{{ Batch.Id }}: {{ Batch.Name }}" )]
+    [LavaField( "Journal Memo Lava", "Lava for the journal memo per line. Default: Batch.Id: Batch.Name", true, "{{ Batch.Id }}: {{ Batch.Name }}" )]
     [BooleanField( "Enable Debug", "Outputs the object graph to help create your Lava syntax. (Debug data will show after clicking export.)", false )]
 
     #endregion
@@ -183,7 +183,7 @@ namespace RockWeb.Plugins.rocks_kfs.Intacct
                 var endpoint = new IntacctEndpoint();
                 var debugLava = GetAttributeValue( "EnableDebug" );
 
-                var postXml = journal.CreateJournalEntryXML( intacctAuth, _financialBatch.Id, GetAttributeValue( "JournalId" ), ref debugLava, GetAttributeValue( "JournalDescriptionLava" ) );
+                var postXml = journal.CreateJournalEntryXML( intacctAuth, _financialBatch.Id, GetAttributeValue( "JournalId" ), ref debugLava, GetAttributeValue( "JournalMemoLava" ) );
                 var resultXml = endpoint.PostToIntacct( postXml );
                 var success = endpoint.ParseEndpointResponse( resultXml, _financialBatch.Id, GetAttributeValue( "LogResponse" ).AsBoolean() );
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added support for a lava customization memo field per line item on export. Including an "Enable Debug" feature to show the available fields on export. (Including it adds something to the memo line in general, prior to this version it was blank).

**New Settings:**

- `Journal Memo Lava`: adds the ability to customize what information you have per line in the export (Default: Batch.Id: Batch.Name)
- `Enable Debug` outputs the object graph after export to help create your lava syntax.
---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added data to memo column of export and gave it the ability to be customized via lava in the block settings.

---------

### Requested By

##### Who reported, requested, or paid for the change?

OHC

---------

### Screenshots

##### Does this update or add options to the block UI?

[Add a screenshot here]
![image](https://user-images.githubusercontent.com/2990519/71689535-7d90b500-2d5f-11ea-8510-304433627685.png)

![image](https://user-images.githubusercontent.com/2990519/71689706-fa239380-2d5f-11ea-9b73-440920ed29a3.png)

---------

### Change Log

##### What files does it affect?

- Intacct/BatchToJournal.ascx
- Intacct/BatchToJournal.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Requires assembly update in https://github.com/KingdomFirst/RockAssemblies/pull/9
