### PR TITLE
Fundraising progress Update

### DIFF
--- a/Fundraising/FundraisingProgress.ascx
+++ b/Fundraising/FundraisingProgress.ascx
@@ -17,7 +17,7 @@
                     <h2 style="padding-top: 20px; letter-spacing: 4px; word-spacing: 4px;"><strong>Total raised year to date:</strong></h2>
                     <div style="margin-top: 20px;">
                         <div style="padding: 10px 15px; background: #fd5200; color: white; max-width: 500px; font-size: 35px; margin: auto;">
-                            $<%=this.GroupContributionTotal%>
+                            $<%=this.GroupContributionTotal.ToString("N")%>
                         </div>
                     </div>
 
@@ -26,7 +26,7 @@
                 <asp:Panel ID="pnlHeader" runat="server" class="bg-color padding-t-md padding-l-md padding-r-md padding-b-sm">
                     <div class="clearfix">
                         <b>Total Individual Goals</b>
-                        <p id="pTotalAmounts" runat="server" class="pull-right" style="margin-bottom: 0;"><strong>$<%=this.GroupContributionTotal%>/$<%=this.GroupIndividualFundraisingGoal%></strong></p>
+                        <p id="pTotalAmounts" runat="server" class="pull-right" style="margin-bottom: 0;"><strong>$<%=this.GroupContributionTotal.ToString("N")%>/$<%=this.GroupIndividualFundraisingGoal.ToString("N")%></strong></p>
                     </div>
 
                     <div class="progress" id="divTotalProgress" runat="server" style="margin-top: 12px;">

--- a/Fundraising/FundraisingProgress.ascx
+++ b/Fundraising/FundraisingProgress.ascx
@@ -13,14 +13,11 @@
                     </h1>
                 </div>
 
-                <div style="text-align: center; text-transform: uppercase;" id="divTotalRaised" runat="server">
-                    <h2 style="padding-top: 20px; letter-spacing: 4px; word-spacing: 4px;"><strong>Total raised year to date:</strong></h2>
-                    <div style="margin-top: 20px;">
-                        <div style="padding: 10px 15px; background: #fd5200; color: white; max-width: 500px; font-size: 35px; margin: auto;">
-                            $<%=this.GroupContributionTotal.ToString("N")%>
-                        </div>
+                <div id="divTotalRaised" runat="server" class="text-center total-raised">
+                    <h2 class="padding-top-lg total-raised-h2">Total raised year to date:</h2>
+                    <div class="padding-h-xl padding-v-md alert alert-default h1 alert-total-raised">
+                        $<%=this.GroupContributionTotal.ToString("N")%>
                     </div>
-
                 </div>
 
                 <asp:Panel ID="pnlHeader" runat="server" class="bg-color padding-t-md padding-l-md padding-r-md padding-b-sm">

--- a/Fundraising/FundraisingProgress.ascx
+++ b/Fundraising/FundraisingProgress.ascx
@@ -13,6 +13,16 @@
                     </h1>
                 </div>
 
+                <div style="text-align: center; text-transform: uppercase;" id="divTotalRaised" runat="server">
+                    <h2 style="padding-top: 20px; letter-spacing: 4px; word-spacing: 4px;"><strong>Total raised year to date:</strong></h2>
+                    <div style="margin-top: 20px;">
+                        <div style="padding: 10px 15px; background: #fd5200; color: white; max-width: 500px; font-size: 35px; margin: auto;">
+                            $<%=this.GroupContributionTotal%>
+                        </div>
+                    </div>
+
+                </div>
+
                 <asp:Panel ID="pnlHeader" runat="server" class="bg-color padding-t-md padding-l-md padding-r-md padding-b-sm">
                     <div class="clearfix">
                         <b>Total Individual Goals</b>
@@ -45,6 +55,7 @@
                                             </div>
                                         </div>
                                     </asp:Panel>
+                                </div>
                             </li>
                         </ItemTemplate>
                     </asp:Repeater>
@@ -54,5 +65,5 @@
     </ContentTemplate>
 </asp:UpdatePanel>
 <asp:Panel runat="server" ID="pnlActions" CssClass="actions">
-    <asp:Button ID="btnExport" runat="server" Text="Export to Excel" CssClass="btn btn-primary" OnClick="btnExport_Click"/>
+    <asp:Button ID="btnExport" runat="server" Text="Export to Excel" CssClass="btn btn-primary" OnClick="btnExport_Click" />
 </asp:Panel>

--- a/Fundraising/FundraisingProgress.ascx.cs
+++ b/Fundraising/FundraisingProgress.ascx.cs
@@ -32,9 +32,11 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using OfficeOpenXml;
+
 using Rock;
 using Rock.Attribute;
 using Rock.Data;
+using Rock.Lava;
 using Rock.Model;
 using Rock.Utility;
 using Rock.Web.Cache;
@@ -55,13 +57,14 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
     #region Block Settings
 
     [BooleanField( "Show Group Title", "Should the Group Title be displayed?", true, "", 1 )]
-    [BooleanField( "Show Group Total Goals", "Should the total goals be displayed?", true, "", 2 )]
-    [BooleanField( "Show Group Total Goals Amount", "Should the group total goals amount be displayed?", true, "", 3 )]
-    [BooleanField( "Show Group Total Goals Progress Bar", "Should the group total goals progress bar be displayed?", true, "", 4 )]
-    [BooleanField( "Show Group Member Goals", "Should group member goals be displayed?", true, "", 5 )]
-    [BooleanField( "Show Group Member Goal Amounts", "Should group member goal amounts be displayed?", true, "", 6 )]
-    [BooleanField( "Show Group Member Goal Progress Bars", "Should group member goal progress bars be displayed?", true, "", 7 )]
-    [BooleanField( "Show Excel Export Button", "Should the Excel Export Button be displayed?", false, "", 8 )]
+    [BooleanField( "Show Total Amount Raised", "Should the total amount raised be displayed?", false, "", 2 )]
+    [BooleanField( "Show Group Total Goals", "Should the total goals be displayed?", true, "", 3 )]
+    [BooleanField( "Show Group Total Goals Amount", "Should the group total goals amount be displayed?", true, "", 4 )]
+    [BooleanField( "Show Group Total Goals Progress Bar", "Should the group total goals progress bar be displayed?", true, "", 5 )]
+    [BooleanField( "Show Group Member Goals", "Should group member goals be displayed?", true, "", 6 )]
+    [BooleanField( "Show Group Member Goal Amounts", "Should group member goal amounts be displayed?", true, "", 7 )]
+    [BooleanField( "Show Group Member Goal Progress Bars", "Should group member goal progress bars be displayed?", true, "", 8 )]
+    [BooleanField( "Show Excel Export Button", "Should the Excel Export Button be displayed?", false, "", 9 )]
 
     #endregion
 
@@ -114,12 +117,14 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                     pnlView.Visible = false;
                 }
 
+                divTotalRaised.Visible = GetAttributeValue( "ShowTotalAmountRaised" ).AsBoolean();
                 divPanelHeading.Visible = GetAttributeValue( "ShowGroupTitle" ).AsBoolean();
                 pnlHeader.Visible = GetAttributeValue( "ShowGroupTotalGoals" ).AsBoolean();
                 pTotalAmounts.Visible = GetAttributeValue( "ShowGroupTotalGoalsAmount" ).AsBoolean();
                 divTotalProgress.Visible = GetAttributeValue( "ShowGroupTotalGoalsProgressBar" ).AsBoolean();
                 ulGroupMembers.Visible = GetAttributeValue( "ShowGroupMemberGoals" ).AsBoolean();
                 pnlActions.Visible = GetAttributeValue( "ShowExcelExportButton" ).AsBoolean();
+
             }
         }
 
@@ -160,6 +165,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
             lTitle.Text = group.Name.FormatAsHtmlTitle();
 
             BindGroupMembersProgressGrid( group, groupMember, rockContext );
+
         }
 
         /// <summary>
@@ -217,6 +223,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                     progressBarWidth = 100;
                 }
 
+
                 if ( !individualFundraisingGoal.HasValue )
                 {
                     individualFundraisingGoal = 0;
@@ -243,6 +250,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
 
             rptFundingProgress.DataSource = groupMemberList;
             rptFundingProgress.DataBind();
+
         }
 
         #endregion
@@ -301,8 +309,6 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
 
             return cssClass;
         }
-
-        #endregion
 
         protected void btnExport_Click( object sender, EventArgs e )
         {
@@ -428,4 +434,6 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
             }
         }
     }
+
+    #endregion
 }

--- a/Fundraising/FundraisingProgress.ascx.cs
+++ b/Fundraising/FundraisingProgress.ascx.cs
@@ -227,9 +227,9 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
 
                 return new
                 {
-                    FullName = groupMember.Person.FullName,
-                    NickName = groupMember.Person.NickName,
-                    LastName = groupMember.Person.LastName,
+                    groupMember.Person.FullName,
+                    groupMember.Person.NickName,
+                    groupMember.Person.LastName,
                     GroupName = group.Name,
                     IndividualFundraisingGoal = ( individualFundraisingGoal ?? 0.00M ).ToString( "0.##" ),
                     ContributionTotal = contributionTotal.ToString( "0.##" ),
@@ -239,6 +239,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                 };
             } ).ToList();
             Session["IndividualData"] = groupMemberList;
+
             this.GroupIndividualFundraisingGoal = groupMemberList.Sum( a => decimal.Parse( a.IndividualFundraisingGoal ) );
             this.GroupContributionTotal = groupMemberList.Sum( a => decimal.Parse( a.ContributionTotal ) );
             this.PercentComplete = decimal.Round( this.GroupIndividualFundraisingGoal == 0 ? 100 : this.GroupContributionTotal / ( this.GroupIndividualFundraisingGoal * 0.01M ), 2 );

--- a/Fundraising/FundraisingProgress.ascx.cs
+++ b/Fundraising/FundraisingProgress.ascx.cs
@@ -36,7 +36,6 @@ using OfficeOpenXml;
 using Rock;
 using Rock.Attribute;
 using Rock.Data;
-using Rock.Lava;
 using Rock.Model;
 using Rock.Utility;
 using Rock.Web.Cache;
@@ -52,7 +51,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
     [Category( "KFS > Fundraising" )]
     [Description( "Progress for all people in a fundraising opportunity" )]
 
-    #endregion
+    #endregion Block Attributes
 
     #region Block Settings
 
@@ -66,7 +65,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
     [BooleanField( "Show Group Member Goal Progress Bars", "Should group member goal progress bars be displayed?", true, "", 8 )]
     [BooleanField( "Show Excel Export Button", "Should the Excel Export Button be displayed?", false, "", 9 )]
 
-    #endregion
+    #endregion Block Settings
 
     public partial class FundraisingProgress : RockBlock
     {
@@ -77,7 +76,7 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
         public decimal GroupContributionTotal;
         public string ProgressCssClass;
 
-        #endregion
+        #endregion Fields
 
         #region Base Control Methods
 
@@ -124,13 +123,12 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                 divTotalProgress.Visible = GetAttributeValue( "ShowGroupTotalGoalsProgressBar" ).AsBoolean();
                 ulGroupMembers.Visible = GetAttributeValue( "ShowGroupMemberGoals" ).AsBoolean();
                 pnlActions.Visible = GetAttributeValue( "ShowExcelExportButton" ).AsBoolean();
-
             }
         }
 
-        #endregion
+        #endregion Base Control Methods
 
-        #region Methods
+        #region Protected Methods
 
         /// <summary>
         /// Shows the view.
@@ -165,7 +163,6 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
             lTitle.Text = group.Name.FormatAsHtmlTitle();
 
             BindGroupMembersProgressGrid( group, groupMember, rockContext );
-
         }
 
         /// <summary>
@@ -223,7 +220,6 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                     progressBarWidth = 100;
                 }
 
-
                 if ( !individualFundraisingGoal.HasValue )
                 {
                     individualFundraisingGoal = 0;
@@ -250,64 +246,6 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
 
             rptFundingProgress.DataSource = groupMemberList;
             rptFundingProgress.DataBind();
-
-        }
-
-        #endregion
-
-        #region Events
-
-        /// <summary>
-        /// Handles the BlockUpdated event of the Block control.
-        /// </summary>
-        /// <param name="sender">The source of the event.</param>
-        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        protected void Block_BlockUpdated( object sender, EventArgs e )
-        {
-            ShowView( hfGroupId.Value.AsIntegerOrNull(), hfGroupMemberId.Value.AsIntegerOrNull() );
-        }
-
-        /// <summary>
-        /// Handles the ItemDataBound event of the rptFundingProgress control.
-        /// </summary>
-        /// <param name="sender">The source of the event.</param>
-        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
-        protected void rptFundingProgress_ItemDataBound( object sender, RepeaterItemEventArgs e )
-        {
-            var divMemberGoalAmount = e.Item.FindControl( "divMemberGoalAmount" );
-            var pnlMemberGoalProgressBar = e.Item.FindControl( "pnlMemberGoalProgressBar" ) as Panel;
-
-            divMemberGoalAmount.Visible = GetAttributeValue( "ShowGroupMemberGoalAmounts" ).AsBoolean();
-            pnlMemberGoalProgressBar.Visible = GetAttributeValue( "ShowGroupMemberGoalProgressBars" ).AsBoolean();
-
-            if ( divMemberGoalAmount.Visible )
-            {
-                pnlMemberGoalProgressBar.CssClass = "col-xs-12 col-md-8 col-md-offset-4";
-            }
-            else
-            {
-                pnlMemberGoalProgressBar.CssClass = "col-xs-12 col-md-8";
-            }
-        }
-
-        #endregion
-
-        #region Methods
-
-        private string GetProgressCssClass( decimal percentage )
-        {
-            var cssClass = "warning";
-
-            if ( percentage >= 100 )
-            {
-                cssClass = "success";
-            }
-            else if ( percentage > 40 && percentage < 100 )
-            {
-                cssClass = "info";
-            }
-
-            return cssClass;
         }
 
         protected void btnExport_Click( object sender, EventArgs e )
@@ -433,7 +371,64 @@ namespace RockWeb.Plugins.rocks_kfs.Fundraising
                 }
             }
         }
-    }
 
-    #endregion
+        #endregion Protected Methods
+
+        #region Events
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the Block control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            ShowView( hfGroupId.Value.AsIntegerOrNull(), hfGroupMemberId.Value.AsIntegerOrNull() );
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptFundingProgress control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
+        protected void rptFundingProgress_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        {
+            var divMemberGoalAmount = e.Item.FindControl( "divMemberGoalAmount" );
+            var pnlMemberGoalProgressBar = e.Item.FindControl( "pnlMemberGoalProgressBar" ) as Panel;
+
+            divMemberGoalAmount.Visible = GetAttributeValue( "ShowGroupMemberGoalAmounts" ).AsBoolean();
+            pnlMemberGoalProgressBar.Visible = GetAttributeValue( "ShowGroupMemberGoalProgressBars" ).AsBoolean();
+
+            if ( divMemberGoalAmount.Visible )
+            {
+                pnlMemberGoalProgressBar.CssClass = "col-xs-12 col-md-8 col-md-offset-4";
+            }
+            else
+            {
+                pnlMemberGoalProgressBar.CssClass = "col-xs-12 col-md-8";
+            }
+        }
+
+        #endregion Events
+
+        #region Private Methods
+
+        private string GetProgressCssClass( decimal percentage )
+        {
+            var cssClass = "warning";
+
+            if ( percentage >= 100 )
+            {
+                cssClass = "success";
+            }
+            else if ( percentage > 40 && percentage < 100 )
+            {
+                cssClass = "info";
+            }
+
+            return cssClass;
+        }
+
+        #endregion Private Methods
+    }
 }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Found a discrepancy of our block on a clients server that needed to be pulled in to our repo. Total Amount raised option was not in our code. You can have it show as a progress bar or a single number with this setting.

**New Settings:**

*Show Total Amount Raised* added.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Show Total Amount Raised added as an option to our block and fixed to properly show decimals.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/76118039-4b434400-5faa-11ea-85de-c10bbceef953.png)

*Customized for client:*
![image](https://user-images.githubusercontent.com/2990519/76116569-737d7380-5fa7-11ea-8451-7e49a4c7c5d9.png)

---------

### Change Log

##### What files does it affect?

- Fundraising/FundraisingProgress.ascx
- Fundraising/FundraisingProgress.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
