### PR TITLE
Fix for group finder default location. Somewhere along the line, v10i…

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1364,11 +1364,11 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     {
                         personLocation = new LocationService( rockContext )
                         .Get( acAddress.Street1, acAddress.Street2, acAddress.City,
-                            acAddress.State, acAddress.PostalCode, acAddress.Country );
+                            acAddress.State, acAddress.PostalCode, acAddress.Country, null, true, false );
                         if ( personLocation.GeoPoint != null ) mapCoordinate = new MapCoordinate( personLocation.Latitude, personLocation.Longitude );
                     }
 
-                    if ( personLocation == null )
+                    if ( personLocation == null || ( personLocation != null && personLocation.GeoPoint == null ) )
                     {
                         Guid? campusGuid = GetAttributeValue( "DefaultLocation" ).AsGuidOrNull();
                         if ( campusGuid != null )

--- a/Groups/GroupFinder_Readme.md
+++ b/Groups/GroupFinder_Readme.md
@@ -1,0 +1,28 @@
+## KFS Custom Group Finder
+
+*Tested/Supported in Rock version: 9.0-10.2*
+*Released: 9/26/2019*
+*Updated: 7/7/2020*
+
+Our Group finder is a significantly modified version of the core Rock version. Including but not limited to these features:
+
+- Added ability to set default location so when address is enabled a campus can be selected and results auto load.
+- Added single select setting so that multiselect filters will be a drop down.
+- Added ability to set filters by url parameter
+- Added an override setting for PersonGuid mode that enables search options
+- Added postal code search capability
+- Added Collapsible filters
+- Added Custom Sorting based on Attribute Filter
+- Added ability to hide attribute values from the search panel
+
+
+
+**Collapsible Filters Screenshots:**
+
+<img width="439" alt="Filter_SS" src="https://user-images.githubusercontent.com/2990519/64822526-7193a400-d572-11e9-9a3d-7033f94d9a1a.png">
+<img width="442" alt="FilterExpanded_SS" src="https://user-images.githubusercontent.com/2990519/64822527-7193a400-d572-11e9-9bd9-341a5ad30c99.png">
+<img width="430" alt="MoreFilters_SS" src="https://user-images.githubusercontent.com/2990519/64822528-7193a400-d572-11e9-9ab5-4f29440dac9c.png">
+<img width="515" alt="MoreFiltersExpanded_SS" src="https://user-images.githubusercontent.com/2990519/64822529-722c3a80-d572-11e9-819c-536f0b6921f2.png">
+
+**Custom Sorting based on Attribute Filter** (Group with Single AND Kid friendly gets prioritized in search result):   
+[![image](https://user-images.githubusercontent.com/2990519/72023559-5c810600-3230-11ea-9d66-ec262c0e2ae7.png)](https://user-images.githubusercontent.com/2990519/72023559-5c810600-3230-11ea-9d66-ec262c0e2ae7.png)


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed Group Finder not loading default location for distances without Postal Code search being enabled.. Somewhere along the line, v10ish, a new "Get" method was added to location that creates locations it doesn't find, which ends up with invalid/no geo point locations being created and then found by the group finder if not using postal code search. (Fixes #19)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed Group Finder not loading default location for distances without Postal Code search being enabled.

---------

### Requested By

##### Who reported, requested, or paid for the change?

OHC/Warranty 

---------

### Screenshots

##### Does this update or add options to the block UI?

Before:   
![image](https://user-images.githubusercontent.com/2990519/86403543-26ff2780-bc6b-11ea-988d-155eb1f44ad7.png)


After:   
![image](https://user-images.githubusercontent.com/2990519/86403925-e2c05700-bc6b-11ea-8110-5968e7f7bdb6.png)


---------

### Change Log

##### What files does it affect?

- Groups/GroupFinder.ascx.cs
- Groups/GroupFinder_Readme.md

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
