### PR TITLE
Single Select Filter Setting Renamed

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -72,7 +72,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
 
     [BooleanField( "Auto Load", "When set to true, all results will be loaded to begin.", false )]
     [CampusField( "Default Location", "The campus address that should be used as fallback for the search criteria.", false, "", "" )]
-    [BooleanField( "Single Select Filters", "When set to true, all filters will be a drop down instead of checkbox.", false )]
+    [BooleanField( "Single Select Campus Filter", "When set to true, the campus filter will be a drop down instead of checkbox.", false, key: "SingleSelectFilters" )]
     [BooleanField( "Allow Search in PersonGuid Mode", "When set to true PersonGuid mode will allow you to change filters and search in that mode for that person.", false, key: "AllowSearchPersonGuid" )]
     [BooleanField( "Collapse Filters on Search", "When set to true, all filters will be collapsed into a single 'Filters' dropdown.", false )]
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Looked into issue #25 and found that it is by design that it only affects the campus filter, but is a misleading name and description on the block setting. It would take a lot of work to get all filters converted to single select due to using helper methods.

**New Settings:**

**Single Select Campus Filter**

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Renamed block setting *Single Select Filters* to **Single Select Campus Filter**

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty / reported in #25 

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/95790448-9dfd8080-0c9c-11eb-9795-4d9c90cadeb7.png)


---------

### Change Log

##### What files does it affect?

Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
