### PR TITLE
Group Finder Default Location and Postal Code Bug

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1368,7 +1368,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                         if ( personLocation.GeoPoint != null ) mapCoordinate = new MapCoordinate( personLocation.Latitude, personLocation.Longitude );
                     }
 
-                    if ( personLocation == null || ( personLocation != null && personLocation.GeoPoint == null ) )
+                    if ( mapCoordinate == null && personLocation == null || ( personLocation != null && personLocation.GeoPoint == null ) )
                     {
                         Guid? campusGuid = GetAttributeValue( "DefaultLocation" ).AsGuidOrNull();
                         if ( campusGuid != null )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Check if they entered a postal code and it got a map coordinate before loading the default location... 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed issue where using a default location would override any postal code entered by the user.

---------

### Requested By

##### Who reported, requested, or paid for the change?

LGO

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
