### PR TITLE
Don't require the block setting for Default Check-In Group Type.

### DIFF
--- a/CheckIn/AttendanceReport.ascx.cs
+++ b/CheckIn/AttendanceReport.ascx.cs
@@ -48,9 +48,8 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
     [GroupTypeField(
         name: "Default Check-In Group Type",
         description: "The default Check-In Configuration when the page loads.",
-        required: true,
+        required: false,
         groupTypePurposeValueGuid: Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE,
-        defaultGroupTypeGuid: Rock.SystemGuid.GroupType.GROUPTYPE_WEEKLY_SERVICE_CHECKIN_AREA,
         order: 0,
         key: AttributeKeys.DefaultCheckInGroupType )]
     [CategoryField(
@@ -262,7 +261,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
         {
             if ( ddlCheckInConfiguration.SelectedValue.IsNullOrWhiteSpace() )
             {
-                ddlCheckInConfiguration.SelectedValue = GetDefaultGroupTypeIdFromBlockSettings().ToString();
+                ddlCheckInConfiguration.SelectedValue = GetDefaultGroupTypeIdFromBlockSettings();
             }
 
             CheckInConfigurationTypeId = ddlCheckInConfiguration.SelectedValue;
@@ -376,10 +375,16 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
         /// Gets the default group type identifier from block settings.
         /// </summary>
         /// <returns></returns>
-        private int GetDefaultGroupTypeIdFromBlockSettings()
+        private string GetDefaultGroupTypeIdFromBlockSettings()
         {
-            var guid = GetAttributeValue( AttributeKeys.DefaultCheckInGroupType ).AsGuid();
-            return new GroupTypeService( _rockContext ).Get( guid ).Id;
+            var guid = GetAttributeValue( AttributeKeys.DefaultCheckInGroupType ).AsGuidOrNull();
+
+            if ( guid.HasValue )
+            {
+                return GroupTypeCache.Get( guid.Value ).Id.ToString();
+            }
+
+            return string.Empty;
         }
 
         /// <summary>
@@ -396,7 +401,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
                 .OrderBy( c => c.Order )
                 .ThenBy( c => c.Name )
                 .ToList();
-            ddlCheckInConfiguration.SelectedValue = GetDefaultGroupTypeIdFromBlockSettings().ToString();
+            ddlCheckInConfiguration.SelectedValue = GetDefaultGroupTypeIdFromBlockSettings();
             CheckInConfigurationTypeId = ddlCheckInConfiguration.SelectedValue;
         }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Makes the Default Check-In Group Type block setting optional.  By not forcing a Group Type in the block settings, this ensures intentionality when running the report.

When I initially wrote the block, I thought this value would be required at all times.  Now that the block is fully functioning, I was able to confirm a `string.Empty` value allows all dependent data bindings to reset and display blank.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Made the Default Check-In Group Type setting optional in the Attendance Report block.

---------

### Change Log

##### What files does it affect?

* CheckIn/AttendanceReport.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
