### PR TITLE
Import Person with Attendance Updates

### DIFF
--- a/Import/sql/_rocks_kfs_spPersonImportWithAttendance_CSV.sql
+++ b/Import/sql/_rocks_kfs_spPersonImportWithAttendance_CSV.sql
@@ -55,10 +55,15 @@ SELECT @Status = COUNT(1) FROM INFORMATION_SCHEMA.COLUMNS
 WHERE [TABLE_NAME] = ''' + @ImportTable + '''
    AND COLUMN_NAME = ''Email''
 
-IF @Status < 1 
+DECLARE @Status2 INT
+SELECT @Status2 = COUNT(1) FROM INFORMATION_SCHEMA.COLUMNS
+WHERE [TABLE_NAME] = ''' + @ImportTable + '''
+   AND COLUMN_NAME = ''BirthDate''
+
+IF @Status < 1 AND @Status2 < 1
 BEGIN 
     RAISERROR(''Table does not contain the correct column definitions:'', 0, 10) WITH NOWAIT;
-    RAISERROR(''FirstName,LastName,BirthDate,Email,ConnectionStatusId,GroupID,AttendanceTimestamp,Gender'', 0, 10) WITH NOWAIT;
+    RAISERROR(''FirstName,LastName,Email,BirthDate,ConnectionStatusId,GroupID,AttendanceTimestamp,Gender'', 0, 10) WITH NOWAIT;
     WAITFOR DELAY ''00:00:01'';
 END
 ';
@@ -88,17 +93,53 @@ CREATE TABLE _rocks_kfs_peopleCsvTemp (
 	PersonId INT
 );
 
-DECLARE @StatusGroupID INT
-DECLARE @StatusAttendanceTimestamp INT
+DECLARE @HasEmailCol INT
+DECLARE @HasBirthDateCol INT
+DECLARE @HasGenderCol INT
+DECLARE @HasConnectionStatusCol INT
+DECLARE @HasGroupIdCol INT
+DECLARE @HasAttendanceTimestampCol INT
 
 -- Populate Temp Table
+SELECT @cmd = '
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+WHERE [TABLE_NAME] = ''' + @ImportTable + '''
+   AND COLUMN_NAME = ''Email''
+';
+EXEC(@cmd)
+SET @HasEmailCol = @@ROWCOUNT
+
+SELECT @cmd = '
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+WHERE [TABLE_NAME] = ''' + @ImportTable + '''
+   AND COLUMN_NAME = ''BirthDate''
+';
+EXEC(@cmd)
+SET @HasBirthDateCol = @@ROWCOUNT
+
+SELECT @cmd = '
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+WHERE [TABLE_NAME] = ''' + @ImportTable + '''
+   AND COLUMN_NAME = ''Gender''
+';
+EXEC(@cmd)
+SET @HasGenderCol = @@ROWCOUNT
+
+SELECT @cmd = '
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+WHERE [TABLE_NAME] = ''' + @ImportTable + '''
+   AND COLUMN_NAME = ''ConnectionStatusId''
+';
+EXEC(@cmd)
+SET @HasConnectionStatusCol = @@ROWCOUNT
+
 SELECT @cmd = '
 SELECT * FROM INFORMATION_SCHEMA.COLUMNS
 WHERE [TABLE_NAME] = ''' + @ImportTable + '''
    AND COLUMN_NAME = ''GroupID''
 ';
 EXEC(@cmd)
-SET @StatusGroupID = @@ROWCOUNT
+SET @HasGroupIdCol = @@ROWCOUNT
 
 SELECT @cmd = '
 SELECT * FROM INFORMATION_SCHEMA.COLUMNS
@@ -106,29 +147,43 @@ WHERE [TABLE_NAME] = ''' + @ImportTable + '''
    AND COLUMN_NAME = ''AttendanceTimestamp''
 ';
 EXEC(@cmd)
-SET @StatusAttendanceTimestamp = @@ROWCOUNT
+SET @HasAttendanceTimestampCol = @@ROWCOUNT
 
 -- Populate Temp Table
 SELECT @cmd = '
 ;WITH personData AS (
     SELECT * FROM ' + QUOTENAME(@ImportTable) +
 ')
-INSERT _rocks_kfs_peopleCsvTemp (FirstName, LastName, BirthDate, Email, Gender, ForeignGuid, GroupID, AttendanceTimestamp)
-SELECT 
-    CASE WHEN NULLIF(LTRIM([FirstName]), '''') IS NULL THEN RIGHT(Email, LEN(Email) - CHARINDEX(''@'', email)) ELSE [FirstName] END,
-	CASE WHEN NULLIF(LTRIM([LastName]), '''') IS NULL THEN LEFT(Email, LEN(Email) - CHARINDEX(''@'', email)) ELSE [LastName] END,
-    CONVERT(DATE, BirthDate),
-	Email,
+INSERT _rocks_kfs_peopleCsvTemp (FirstName, LastName, Email, BirthDate, Gender, ConnectionStatusId, ForeignGuid, GroupID, AttendanceTimestamp)
+SELECT '+
+    CASE 
+        WHEN @HasEmailCol = 1 THEN
+            'CASE WHEN NULLIF(LTRIM([FirstName]), '''') IS NULL THEN RIGHT(Email, LEN(Email) - CHARINDEX(''@'', email)) ELSE [FirstName] END,
+	         CASE WHEN NULLIF(LTRIM([LastName]), '''') IS NULL THEN LEFT(Email, LEN(Email) - CHARINDEX(''@'', email)) ELSE [LastName] END, 
+	         Email, '
+        ELSE '[FirstName], [LastName], '''', '
+    END +
+    CASE 
+        WHEN @HasBirthDateCol = 1 THEN 'CASE WHEN LTRIM(BirthDate) != '''' THEN CONVERT(DATE, BirthDate) ELSE NULL END, '
+        ELSE 'NULL, '
+    END +
+    CASE 
+        WHEN @HasGenderCol = 1 THEN 'CASE
+                WHEN Gender = ''Female'' THEN 2
+                WHEN Gender = ''Male'' THEN 1
+                ELSE 0
+            END AS Gender, '
+        ELSE '0, '
+    END +
+    CASE 
+        WHEN @HasConnectionStatusCol = 1 THEN 'ConnectionStatusId, '
+        ELSE '66, '
+    END
+    +' NEWID()'+
     CASE
-        WHEN Gender = ''Female'' THEN 2
-        WHEN Gender = ''Male'' THEN 1
-        ELSE 0
-    END AS Gender,
-	NEWID()'+
-    CASE
-        WHEN @StatusGroupID = 1 AND @StatusAttendanceTimestamp = 1 THEN ', CONVERT(INT, GroupID), AttendanceTimestamp'
-        WHEN @StatusGroupID = 1 AND @StatusAttendanceTimestamp = 0 THEN ', CONVERT(INT, GroupID), NULL'
-        WHEN @StatusGroupID = 0 AND @StatusAttendanceTimestamp = 1 THEN ', NULL, AttendanceTimestamp'
+        WHEN @HasGroupIdCol = 1 AND @HasAttendanceTimestampCol = 1 THEN ', CONVERT(INT, GroupID), AttendanceTimestamp'
+        WHEN @HasGroupIdCol = 1 AND @HasAttendanceTimestampCol = 0 THEN ', CONVERT(INT, GroupID), NULL'
+        WHEN @HasGroupIdCol = 0 AND @HasAttendanceTimestampCol = 1 THEN ', NULL, AttendanceTimestamp'
         ELSE ', NULL, NULL'
     END
     +'
@@ -144,7 +199,7 @@ DECLARE @Status NVARCHAR(1000)
 ), RockMatch AS (
     SELECT missingPeople = STUFF( (SELECT '','' + fd.[FirstName] + '' '' + fd.[LastName] FROM personData fd
     LEFT JOIN Person p
-        ON p.Email = fd.Email OR p.BirthDate = fd.BirthDate
+        ON (p.Email = fd.Email OR p.BirthDate = fd.BirthDate)
         AND p.LastName = RTRIM(LTRIM(fd.[LastName]))
         AND (p.FirstName = RTRIM(LTRIM(fd.[FirstName]))
             OR p.NickName = RTRIM(LTRIM(fd.[FirstName])))
@@ -177,7 +232,7 @@ SELECT @cmd = '
 		fd.ForeignGuid
     FROM personData fd
     LEFT JOIN Person p
-		ON p.Email = fd.Email
+		ON (p.Email = fd.Email OR p.BirthDate = fd.BirthDate)
 		AND p.LastName = RTRIM(LTRIM(fd.[LastName]))
 		AND (p.FirstName = RTRIM(LTRIM(fd.[FirstName]))
 			OR p.NickName = RTRIM(LTRIM(fd.[FirstName])))

--- a/Import/sql/_rocks_kfs_spPersonImportWithAttendance_CSV.sql
+++ b/Import/sql/_rocks_kfs_spPersonImportWithAttendance_CSV.sql
@@ -99,6 +99,7 @@ DECLARE @HasGenderCol INT
 DECLARE @HasConnectionStatusCol INT
 DECLARE @HasGroupIdCol INT
 DECLARE @HasAttendanceTimestampCol INT
+DECLARE @StatusString VARCHAR(max)
 
 -- Populate Temp Table
 SELECT @cmd = '
@@ -307,6 +308,11 @@ FROM NewGroupMembers
 
 EXEC(@cmd)
 
+SELECT @StatusString = CONCAT(@@RowCount,' Group Members Added.')
+
+RAISERROR(@StatusString, 0, 10) WITH NOWAIT;
+WAITFOR DELAY '00:00:01';
+
 RAISERROR('Adding/Updating attendance...', 0, 10) WITH NOWAIT;
 WAITFOR DELAY '00:00:01';
 
@@ -345,6 +351,10 @@ FROM NewAttendance GROUP BY OccurrenceId, AttendanceTimestamp, PersonAliasId
 ';
 
 EXEC(@cmd)
+SELECT @StatusString = CONCAT(@@RowCount, ' Attendance Records Added.')
+
+RAISERROR(@StatusString, 0, 10) WITH NOWAIT;
+WAITFOR DELAY '00:00:01';
 
 /* =================================
 Cleanup table post processing


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Various updates to stored procedure to fix some bugs.

- You can now actually not have some columns defined, email/birthdate/connectionstatusid.
- Person matching on birthdate should actually work now.
- Added some status messages on how many group members and attendance records were created.
- Added some logic to test for empty ConnectionStatus and IsEmailActive if no email imported. 
- Adjusted for possible archived group members. They will be unarchived if re-imported.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- You can now actually not have some columns defined, email/birthdate/connectionstatusid.
- Person matching on birthdate should actually work now.
- Added some status messages on how many group members and attendance records were created.
- Added some logic to test for empty ConnectionStatus and IsEmailActive if no email imported. 
- Adjusted for possible archived group members. They will be unarchived if re-imported.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Venture

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/101527279-05594900-394b-11eb-9f17-30f8d7091f9b.png)

Unarchive message:   
![image](https://user-images.githubusercontent.com/2990519/101948181-d6dba800-3bae-11eb-9917-bcc05669d63b.png)

---------

### Change Log

##### What files does it affect?

Import/sql/_rocks_kfs_spPersonImportWithAttendance_CSV.sql

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
