### PR TITLE
Custom Schedule Support in GroupFinder

### DIFF
--- a/Groups/GroupFinder.ascx
+++ b/Groups/GroupFinder.ascx
@@ -62,12 +62,10 @@
                         <div id="map_wrapper">
                             <div id="map_canvas" class="mapping"></div>
                         </div>
-                        <asp:Literal ID="lMapInfoDebug" runat="server" />
                     </asp:Panel>
 
                     <asp:Panel ID="pnlLavaOutput" runat="server" CssClass="margin-v-sm">
                         <asp:Literal ID="lLavaOverview" runat="server" />
-                        <asp:Literal ID="lLavaOutputDebug" runat="server" />
                     </asp:Panel>
 
                     <asp:Panel ID="pnlGrid" runat="server" CssClass="margin-v-sm">
@@ -152,7 +150,7 @@
                                     <div class="col-md-6">
                                         <Rock:RockCheckBox ID="cbShowMap" runat="server" Label="Map" Text="Yes"
                                             Help="Should a map be displayed that shows the location of each group?" ValidationGroup="GroupFinderSettings" />
-                                        <Rock:RockDropDownList ID="ddlMapStyle" runat="server" Label="Map Style"
+                                        <Rock:DefinedValuePicker ID="dvpMapStyle" runat="server" Label="Map Style"
                                             Help="The map theme that should be used for styling the map." ValidationGroup="GroupFinderSettings" />
                                         <Rock:NumberBox ID="nbMapHeight" runat="server" Label="Map Height"
                                             Help="The pixel height to use for the map." ValidationGroup="GroupFinderSettings" />
@@ -201,9 +199,11 @@
                                         <Rock:RockCheckBox ID="cbShowDescription" runat="server" Label="Show Description" Text="Yes"
                                             Help="Should the description for each group be displayed?" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockCheckBox ID="cbShowCount" runat="server" Label="Show Member Count" Text="Yes"
-                                            Help="Should the number of members in each group be displayed in the result grid?" ValidationGroup="GroupFinderSettings" />
+                                            Help="Should the number of active members in each group be displayed in the result grid?" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockCheckBox ID="cbShowAge" runat="server" Label="Show Average Age" Text="Yes"
-                                            Help="Should the average group member age be displayed for each group in the result grid?" ValidationGroup="GroupFinderSettings" />
+                                            Help="Should the average active group member age be displayed for each group in the result grid?" ValidationGroup="GroupFinderSettings" />
+                                        <Rock:RockCheckBox ID="cbIncludePending" runat="server" Label="Include Pending" Text="Yes"
+                                            Help="Should Pending members be included in the member count and average age calculations?" ValidationGroup="GroupFinderSettings" />
                                     </div>
                                     <div class="col-md-6">
                                         <Rock:RockCheckBox ID="cbShowCampus" runat="server" Label="Show Campus" Text="Yes"

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -150,7 +150,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
     [AttributeField( Rock.SystemGuid.EntityType.GROUP, "Attribute Columns", "", false, true, "", "CustomSetting" )]
     [BooleanField( "Sort By Distance", "", false, "CustomSetting" )]
     [TextField( "Page Sizes", "To show a dropdown of page sizes, enter a comma delimited list of page sizes. For example: 10,20 will present a drop down with 10,20,All as options with the default as 10", false, "", "CustomSetting" )]
-	[BooleanField( "Include Pending", "", true, "CustomSetting" )]
+    [BooleanField( "Include Pending", "", true, "CustomSetting" )]
 
     #endregion Block Attributes
 
@@ -965,9 +965,6 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     }
                 }
                 cblCampus.Label = GetAttributeValue( "CampusLabel" );
-                cblCampus.Visible = true;
-                cblCampus.DataSource = CampusCache.All( includeInactive: false );
-                cblCampus.DataBind();
             }
             else
             {
@@ -1213,9 +1210,9 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 {
                     _filterValues.Add( "FilterDows", dowsFilterControl.SelectedValuesAsInt.AsDelimited( "^" ) );
                     groupQry = groupQry.Where( g =>
-                        (g.Schedule.WeeklyDayOfWeek.HasValue &&
-                        dows.Contains( g.Schedule.WeeklyDayOfWeek.Value )) ||
-                        (dowsStr.Any(s => g.Schedule.iCalendarContent.Substring( g.Schedule.iCalendarContent.IndexOf( "BYDAY=" ), 20 ).Contains( s ) ) ) );
+                        ( g.Schedule.WeeklyDayOfWeek.HasValue &&
+                        dows.Contains( g.Schedule.WeeklyDayOfWeek.Value ) ) ||
+                        ( dowsStr.Any( s => g.Schedule.iCalendarContent.Substring( g.Schedule.iCalendarContent.IndexOf( "BYDAY=" ), 20 ).Contains( s ) ) ) );
                 }
             }
 

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -37,15 +37,12 @@ using System.Data.Entity;
 using System.Data.Entity.Spatial;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Runtime.Caching;
 using System.Text;
 using System.Web;
 using System.Web.UI;
-using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 
 using DotLiquid;
-using DotLiquid.Tags;
 using RestSharp.Extensions;
 using Rock;
 using Rock.Attribute;

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -27,6 +27,7 @@
 // * Added Collapsible filters
 // * Added Custom Sorting based on Attribute Filter
 // * Added ability to hide attribute values from the search panel
+// * Added Custom Schedule Support to DOW Filters
 // </notice>
 //
 using System;
@@ -1196,12 +1197,16 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 var dows = new List<DayOfWeek>();
                 dowsFilterControl.SelectedValuesAsInt.ForEach( i => dows.Add( ( DayOfWeek ) i ) );
 
+                var dowsStr = new List<string>();
+                dowsFilterControl.SelectedNames.ForEach( s => dowsStr.Add( s.Left( 2 ).ToUpper() ) );
+
                 if ( dows.Any() )
                 {
                     _filterValues.Add( "FilterDows", dowsFilterControl.SelectedValuesAsInt.AsDelimited( "^" ) );
                     groupQry = groupQry.Where( g =>
-                        g.Schedule.WeeklyDayOfWeek.HasValue &&
-                        dows.Contains( g.Schedule.WeeklyDayOfWeek.Value ) );
+                        (g.Schedule.WeeklyDayOfWeek.HasValue &&
+                        dows.Contains( g.Schedule.WeeklyDayOfWeek.Value )) ||
+                        (dowsStr.Any(s => g.Schedule.iCalendarContent.Substring( g.Schedule.iCalendarContent.IndexOf( "BYDAY=" ), 20 ).Contains( s ) ) ) );
                 }
             }
 
@@ -1230,8 +1235,6 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                              ( g.Schedule.WeeklyDayOfWeek.HasValue &&
                              g.Schedule.WeeklyDayOfWeek.Value == dayOfWeek ) ||
                              ( g.Schedule.iCalendarContent.Substring( g.Schedule.iCalendarContent.IndexOf( "BYDAY=" ), 20 ).Contains( searchStr ) ) );
-                        //   ( g.Schedule.iCalendarContent.Substring( SqlFunctions.CharIndex( g.Schedule.iCalendarContent, "BYDAY=" ).Value, SqlFunctions.CharIndex( g.Schedule.iCalendarContent,"BYDAY=" ).Value - SqlFunctions.CharIndex( g.Schedule.iCalendarContent, ";", SqlFunctions.CharIndex( g.Schedule.iCalendarContent, "BYDAY=" ) ).Value ).Contains( searchStr ) ) );
-
                     }
                 }
             }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added custom schedules search support to group finder. You should now be able to find groups that meet every other Monday, 1st and 3rd Monday, and any other schedule that uses the BYDAY capability of the ical content.

Also brought in missing core changes to group finder. (Pending members, DefinedValuePicker instead of DDL and remove debug specific capabilities).

**New Settings:**

No, just enabled by default.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Custom Schedules are now supported in the Group Finder day of week filter.
- Bring in missing core changes to group finder. 

---------

### Requested By

##### Who reported, requested, or paid for the change?

LGO

---------

### Screenshots

##### Does this update or add options to the block UI?

No, just works.

---------

### Change Log

##### What files does it affect?

- Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, though I guess it could be a change of functionality if you didn't see custom schedules show up in search results before.
