### PR TITLE
GetChannel Feeds Webhook Update

### DIFF
--- a/Webhooks/GetChannelFeeds.ashx
+++ b/Webhooks/GetChannelFeeds.ashx
@@ -282,7 +282,7 @@ namespace RockWeb.Plugins.rocks_kfs.Webhooks
                     {
                         response.Write( mergeFields.lavaDebugInfo() );
                         response.Write( "<pre>" );
-                        response.Write( WebUtility.HtmlEncode( rssTemplate.ResolveMergeFields( mergeFields ) ) );
+                        response.Write( WebUtility.HtmlEncode( outputContent ) );
                         response.Write( "</pre>" );
                         response.Write( "</body>" );
                         response.Write( "</html" );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Pull in cache key changes from Core to our version of GetChannelFeeds webhook.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* CacheDuration is now honored in our GetChannelFeeds webhook.

---------

### Requested By

##### Who reported, requested, or paid for the change?

OHC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Webhooks/GetChannelFeeds.ashx

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
