### PR TITLE
Group Finder Keyword Search

### DIFF
--- a/Groups/GroupFinder.ascx
+++ b/Groups/GroupFinder.ascx
@@ -109,6 +109,7 @@
                                         <Rock:RockTextBox ID="tbTimeOfDayLabel" runat="server" Label="Time of Day Filter Label" Help="The text above the time of day filter" AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockTextBox ID="tbCampusLabel" runat="server" Label="Campus Filter Label" Help="The text above the campus filter" AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockTextBox ID="tbPostalCodeLabel" runat="server" Label="Postal Code Label" Help="The text above the postal code filter" AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
+                                        <Rock:RockTextBox ID="tbKeywordLabel" runat="server" Label="Keyword Label" Help="The text above the Keyword filter" AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockTextBox ID="tbFilterLabel" runat="server" Label="Filter Button Text" Help="When using collapsible filters what does the dropdown button say on it." AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockTextBox ID="tbMoreFiltersLabel" runat="server" Label="More Filters Button Text" Help="When using initial load hidden filters what does the dropdown button say on it." AutoPostBack="true" Required="true" ValidationGroup="GroupFinderSettings" />
                                     </div>
@@ -127,6 +128,8 @@
                                             Help="If the page has a campus context its value will be used as a filter" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockCheckBox ID="cbPostalCode" runat="server" Label="Enable Postal Code Search" Text="Yes"
                                             Help="Set to true to enable simple Postal code search instead of full address." ValidationGroup="GroupFinderSettings" />
+                                        <Rock:RockCheckBox ID="cbKeyword" runat="server" Label="Display Keyword Filter" Text="Yes"
+                                            Help="Display the Keyword filter" ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockCheckBoxList ID="cblAttributes" runat="server" Label="Display Attribute Filters" RepeatDirection="Horizontal"
                                             Help="The group attributes that should be available for user to filter results by." ValidationGroup="GroupFinderSettings" />
                                         <Rock:RockCheckBoxList ID="cblInitialLoadFilters" runat="server" Label="Hide Filters on Initial Load" RepeatDirection="Horizontal"

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -712,7 +712,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 var groupType = GroupTypeCache.Get( gtpGroupType.SelectedGroupTypeId.Value );
                 if ( groupType != null )
                 {
-                    bool hasWeeklyschedule = ( groupType.AllowedScheduleTypes & ScheduleType.Weekly ) == ScheduleType.Weekly;
+                    bool hasWeeklyschedule = ( groupType.AllowedScheduleTypes & ScheduleType.Weekly ) == ScheduleType.Weekly || ( groupType.AllowedScheduleTypes & ScheduleType.Custom ) == ScheduleType.Weekly;
                     rblFilterDOW.Visible = hasWeeklyschedule;
                     cbFilterTimeOfDay.Visible = hasWeeklyschedule;
                     if ( hasWeeklyschedule )
@@ -918,6 +918,15 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             // Clear attribute filter controls and recreate
             phFilterControls.Controls.Clear();
             phFilterControlsCollapsed.Controls.Clear();
+
+            nbPostalCode.Label = GetAttributeValue( "PostalCodeLabel" );
+            nbPostalCode.RequiredErrorMessage = string.Format( "Your {0} is Required", GetAttributeValue( "PostalCodeLabel" ) );
+            if ( hideFilters.Contains( "filter_postalcode" ) )
+            {
+                pnlSearch.Controls.Remove( nbPostalCode );
+                phFilterControlsCollapsed.Controls.Add( nbPostalCode );
+            }
+
             var scheduleFilters = GetAttributeValue( "ScheduleFilters" ).SplitDelimitedValues().ToList();
             if ( scheduleFilters.Contains( "Days" ) )
             {
@@ -978,14 +987,6 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             {
                 ddlCampus.Visible = false;
                 cblCampus.Visible = false;
-            }
-
-            nbPostalCode.Label = GetAttributeValue( "PostalCodeLabel" );
-            nbPostalCode.RequiredErrorMessage = string.Format( "Your {0} is Required", GetAttributeValue( "PostalCodeLabel" ) );
-            if ( hideFilters.Contains( "filter_postalcode" ) )
-            {
-                pnlSearch.Controls.Remove( nbPostalCode );
-                phFilterControlsCollapsed.Controls.Add( nbPostalCode );
             }
 
             btnFilter.InnerHtml = btnFilter.InnerHtml.Replace( "[Filter] ", GetAttributeValue( "FilterLabel" ) + " " );

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -712,7 +712,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 var groupType = GroupTypeCache.Get( gtpGroupType.SelectedGroupTypeId.Value );
                 if ( groupType != null )
                 {
-                    bool hasWeeklyschedule = ( groupType.AllowedScheduleTypes & ScheduleType.Weekly ) == ScheduleType.Weekly || ( groupType.AllowedScheduleTypes & ScheduleType.Custom ) == ScheduleType.Weekly;
+                    bool hasWeeklyschedule = ( groupType.AllowedScheduleTypes & ScheduleType.Weekly ) == ScheduleType.Weekly || ( groupType.AllowedScheduleTypes & ScheduleType.Custom ) == ScheduleType.Custom;
                     rblFilterDOW.Visible = hasWeeklyschedule;
                     cbFilterTimeOfDay.Visible = hasWeeklyschedule;
                     if ( hasWeeklyschedule )

--- a/Groups/GroupFinder_Readme.md
+++ b/Groups/GroupFinder_Readme.md
@@ -1,8 +1,8 @@
 ## KFS Custom Group Finder
 
-*Tested/Supported in Rock version: 9.0-10.2*
+*Tested/Supported in Rock version: 9.0-12*
 *Released: 9/26/2019*
-*Updated: 7/7/2020*
+*Updated: 2/18/2021*
 
 Our Group finder is a significantly modified version of the core Rock version. Including but not limited to these features:
 
@@ -14,6 +14,8 @@ Our Group finder is a significantly modified version of the core Rock version. I
 - Added Collapsible filters
 - Added Custom Sorting based on Attribute Filter
 - Added ability to hide attribute values from the search panel
+- Added Custom Schedule Support to DOW Filters
+- Added Keyword search to search name or description of groups
 
 
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added Keyword search to search name or description of groups. (Had some weird viewstate issues with collapsible filters so it is a fully dynamic filter.)
- Fixed a minor issue with custom group schedules and Postal Code order for `Hidden on Initial Load` setting

**New Settings:**

- Keyword Label
- Display Keyword Search

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added Keyword search to search name or description of groups. 
- Fixed a minor issue with custom group schedules and Postal Code order for `Hidden on Initial Load` setting

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/108134788-0f4aa700-7074-11eb-92fe-f8e109ce4a99.png)

Added settings for Keyword:   
![image](https://user-images.githubusercontent.com/2990519/108134847-2b4e4880-7074-11eb-97ec-8ade52f6f18d.png)


Stark view:   

![image](https://user-images.githubusercontent.com/2990519/108134969-70727a80-7074-11eb-8e32-1bbba5ba587c.png)


![image](https://user-images.githubusercontent.com/2990519/108134919-52a51580-7074-11eb-806f-2c976cce0ed9.png)


---------

### Change Log

##### What files does it affect?

- Groups/GroupFinder.ascx
- Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
