### PR TITLE
Group Finder Pending Members in Group Capacity

### DIFF
--- a/Groups/GroupFinder_Readme.md
+++ b/Groups/GroupFinder_Readme.md
@@ -2,20 +2,21 @@
 
 *Tested/Supported in Rock version: 9.0-12*
 *Released: 9/26/2019*
-*Updated: 2/18/2021*
+*Updated: 3/29/2021*
 
 Our Group finder is a significantly modified version of the core Rock version. Including but not limited to these features:
 
 - Added ability to set default location so when address is enabled a campus can be selected and results auto load.
 - Added single select setting so that multiselect filters will be a drop down.
-- Added ability to set filters by url parameter
-- Added an override setting for PersonGuid mode that enables search options
-- Added postal code search capability
-- Added Collapsible filters
-- Added Custom Sorting based on Attribute Filter
-- Added ability to hide attribute values from the search panel
-- Added Custom Schedule Support to DOW Filters
-- Added Keyword search to search name or description of groups
+- Added ability to set filters by url parameter.
+- Added an override setting for PersonGuid mode that enables search options.
+- Added postal code search capability.
+- Added Collapsible filters.
+- Added Custom Sorting based on Attribute Filter.
+- Added ability to hide attribute values from the search panel.
+- Added Custom Schedule Support to DOW Filters.
+- Added Keyword search to search name or description of groups.
+- Added an additional setting to include Pending members in Over Capacity checking.
 
 
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added an additional setting to include Pending members in Over Capacity checking

**New Settings:**

**Overcapacity Groups include Pending**, When set to true, the Hide Overcapacity Groups setting also takes into account pending members.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added an additional setting to include Pending members in Over Capacity checking

---------

### Requested By

##### Who reported, requested, or paid for the change?

Southbrook

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/112880014-28893f00-9087-11eb-8beb-d411a95546d8.png)

---------

### Change Log

##### What files does it affect?

Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
