### PR TITLE
New Communication List Subscribe (with Categories)

### DIFF
--- a/Communication/CommunicationListSubscribe.ascx
+++ b/Communication/CommunicationListSubscribe.ascx
@@ -37,8 +37,6 @@
                     </asp:Panel>
                 </asp:Panel>
             </div>
-
         </asp:Panel>
-
     </ContentTemplate>
 </asp:UpdatePanel>

--- a/Communication/CommunicationListSubscribe.ascx
+++ b/Communication/CommunicationListSubscribe.ascx
@@ -1,0 +1,44 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="CommunicationListSubscribe.ascx.cs" Inherits="RockWeb.Plugins.rocks_kfs.Communication.CommunicationListSubscribe" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server">
+    <ContentTemplate>
+
+        <asp:Panel ID="pnlView" runat="server" CssClass="panel panel-block">
+
+            <div class="panel-heading">
+                <h1 class="panel-title"><i class="fa fa-bullhorn"></i>Email Preferences</h1>
+            </div>
+            <div class="panel-body">
+                <Rock:NotificationBox ID="nbNoCommunicationLists" runat="server" NotificationBoxType="Info" Text="You are not subscribed to any communication lists." Visible="false" />
+                <asp:Panel ID="pnlCommunicationPreferences" runat="server">
+                    <asp:Panel ID="pnlCategoryRepeaterParent" runat="server" CssClass="grid grid-panel margin-all-sm">
+                        <asp:Repeater ID="rptCommunicationListCategories" runat="server" OnItemDataBound="rptCommunicationListCategories_ItemDataBound">
+                            <ItemTemplate>
+                                <asp:Panel ID="pnlListRepeaterParent" runat="server" CssClass="row">
+                                    <Rock:PanelWidget ID="pwCategoryPanel" runat="server">
+                                        <asp:Repeater ID="rptCommunicationLists" runat="server" OnItemDataBound="rptCommunicationLists_ItemDataBound">
+                                            <ItemTemplate>
+                                                <div class="row">
+                                                    <div class="col-xs-6">
+                                                        <asp:HiddenField ID="hfGroupId" runat="server" />
+                                                        <Rock:RockCheckBox ID="cbCommunicationListIsSubscribed" runat="server" AutoPostBack="true" OnCheckedChanged="cbCommunicationListIsSubscribed_CheckedChanged" />
+                                                        <Rock:NotificationBox ID="nbGroupNotification" runat="server" Visible="false" />
+                                                    </div>
+                                                    <div class="col-xs-6">
+                                                        <Rock:Toggle ID="tglCommunicationPreference" runat="server" OnText="Email" OffText="SMS" ButtonSizeCssClass="btn-xs" OnCssClass="btn-info" OffCssClass="btn-info" OnCheckedChanged="tglCommunicationPreference_CheckedChanged" />
+                                                    </div>
+                                                </div>
+                                            </ItemTemplate>
+                                        </asp:Repeater>
+                                    </Rock:PanelWidget>
+                                </asp:Panel>
+                            </ItemTemplate>
+                        </asp:Repeater>
+                    </asp:Panel>
+                </asp:Panel>
+            </div>
+
+        </asp:Panel>
+
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/Communication/CommunicationListSubscribe.ascx
+++ b/Communication/CommunicationListSubscribe.ascx
@@ -12,7 +12,21 @@
                 <Rock:NotificationBox ID="nbNoCommunicationLists" runat="server" NotificationBoxType="Info" Text="You are not subscribed to any communication lists." Visible="false" />
                 <asp:Panel ID="pnlCommunicationPreferences" runat="server">
                     <asp:Panel ID="pnlCategoryRepeaterParent" runat="server" CssClass="grid grid-panel margin-all-sm">
-                        <asp:Repeater ID="rptCommunicationListCategories" runat="server" OnItemDataBound="rptCommunicationListCategories_ItemDataBound">
+                        <asp:Repeater ID="rptCommunicationListsNoCategories" runat="server" OnItemDataBound="rptCommunicationListsNoCategories_ItemDataBound" Visible="true">
+                            <ItemTemplate>
+                                <div class="row">
+                                    <div class="col-xs-6">
+                                        <asp:HiddenField ID="hfGroupId" runat="server" />
+                                        <Rock:RockCheckBox ID="cbCommunicationListIsSubscribed" runat="server" AutoPostBack="true" OnCheckedChanged="cbCommunicationListIsSubscribed_CheckedChanged" />
+                                        <Rock:NotificationBox ID="nbGroupNotification" runat="server" Visible="false" />
+                                    </div>
+                                    <div class="col-xs-6">
+                                        <Rock:Toggle ID="tglCommunicationPreference" runat="server" OnText="Email" OffText="SMS" ButtonSizeCssClass="btn-xs" OnCssClass="btn-info" OffCssClass="btn-info" OnCheckedChanged="tglCommunicationPreference_CheckedChanged" />
+                                    </div>
+                                </div>
+                            </ItemTemplate>
+                        </asp:Repeater>
+                        <asp:Repeater ID="rptCommunicationListCategories" runat="server" OnItemDataBound="rptCommunicationListCategories_ItemDataBound" Visible="false">
                             <ItemTemplate>
                                 <asp:Panel ID="pnlListRepeaterParent" runat="server" CssClass="row">
                                     <Rock:PanelWidget ID="pwCategoryPanel" runat="server">

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -1,0 +1,440 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI.Controls;
+using Rock.Attribute;
+using Rock.Web.UI;
+using System.Data.Entity;
+
+namespace RockWeb.Plugins.rocks_kfs.Communication
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [DisplayName( "Communication List Subscribe" )]
+    [Category( "KFS > Communication" )]
+    [Description( "Block that allows a person to manage the communication lists that they are subscribed to" )]
+
+    #region Block Attributes
+
+    [GroupCategoryField(
+        "Communication List Categories",
+        Description = "Select the categories of the communication lists to display, or select none to show all that the user is authorized to view.",
+        AllowMultiple = true,
+        GroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_COMMUNICATIONLIST,
+        DefaultValue = Rock.SystemGuid.Category.GROUPTYPE_COMMUNICATIONLIST_PUBLIC,
+        IsRequired = false,
+        Key = AttributeKey.CommunicationListCategories,
+        Order = 1 )]
+    [BooleanField(
+        "Show Medium Preference",
+        Description = "Show the user's current medium preference for each list and allow them to change it.",
+        DefaultBooleanValue = true,
+        Key = AttributeKey.ShowMediumPreference,
+        Order = 2 )]
+    [BooleanField(
+        "Show List Categories",
+        Description = "Show the category of the selected list categories.",
+        DefaultBooleanValue = false,
+        Key = AttributeKey.ShowCommunicationListCategories,
+        Order = 3
+        )]
+    #endregion Block Attributes
+    public partial class CommunicationListSubscribe : RockBlock
+    {
+        #region Attribute Keys
+
+        /// <summary>
+        /// Keys to use for Block Attributes
+        /// </summary>
+        private static class AttributeKey
+        {
+            public const string CommunicationListCategories = "CommunicationListCategories";
+            public const string ShowMediumPreference = "ShowMediumPreference";
+            public const string ShowCommunicationListCategories = "ShowCommunicationListCategories";
+        }
+
+        #endregion Attribute Keys
+
+        #region fields
+
+        /// <summary>
+        /// The person's group member record for each CommunicationListId
+        /// </summary>
+        private Dictionary<int, GroupMember> personCommunicationListsMember = null;
+
+        /// <summary>
+        /// The show medium preference
+        /// </summary>
+        private bool showMediumPreference = true;
+
+        #endregion
+
+        #region Base Control Methods
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            // this event gets fired after block settings are updated. it's nice to repaint the screen if these settings would alter it
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( upnlContent );
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( !Page.IsPostBack )
+            {
+                BindRepeater();
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            BindRepeater();
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptCommunicationLists control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
+        protected void rptCommunicationLists_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        {
+            var group = e.Item.DataItem as Rock.Model.Group;
+            if ( group != null )
+            {
+                var hfGroupId = e.Item.FindControl( "hfGroupId" ) as HiddenField;
+                hfGroupId.Value = group.Id.ToString();
+
+                var groupDescription = group.Description.IsNullOrWhiteSpace() ? string.Empty : $@"<br>{group.Description}";
+                var groupPublicName = group.GetAttributeValue( "PublicName" );
+
+                var cbCommunicationListIsSubscribed = e.Item.FindControl( "cbCommunicationListIsSubscribed" ) as RockCheckBox;
+                cbCommunicationListIsSubscribed.Text = $@"<strong>{groupPublicName}</strong>{groupDescription}";
+                if ( groupPublicName.IsNullOrWhiteSpace() )
+                {
+                    cbCommunicationListIsSubscribed.Text = $@"<strong>{group.Name}</strong>{groupDescription}";
+                }
+
+                var groupMember = personCommunicationListsMember.GetValueOrNull( group.Id );
+                cbCommunicationListIsSubscribed.Checked = groupMember != null && groupMember.GroupMemberStatus == GroupMemberStatus.Active;
+
+                CommunicationType communicationType = CurrentPerson.CommunicationPreference == CommunicationType.SMS ? CommunicationType.SMS : CommunicationType.Email;
+
+                // if GroupMember record has SMS or Email specified, that takes precedence over their Person.CommunicationPreference
+                var groupMemberHasSmsOrEmailPreference = groupMember != null && ( groupMember.CommunicationPreference == CommunicationType.SMS || groupMember.CommunicationPreference == CommunicationType.Email );
+                if ( groupMemberHasSmsOrEmailPreference )
+                {
+                    communicationType = groupMember.CommunicationPreference;
+                }
+
+                var tglCommunicationPreference = e.Item.FindControl( "tglCommunicationPreference" ) as Toggle;
+                tglCommunicationPreference.Checked = communicationType == CommunicationType.Email;
+                tglCommunicationPreference.Visible = showMediumPreference;
+
+            }
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptCommunicationListCategories control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
+        protected void rptCommunicationListCategories_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        {
+            var category = e.Item.DataItem as Rock.Model.Category;
+            var showCategory = this.GetAttributeValue( AttributeKey.ShowCommunicationListCategories ).AsBoolean();
+            if ( category != null )
+            {
+                var pwCategoryPanel = e.Item.FindControl( "pwCategoryPanel" ) as PanelWidget;
+                var rptCommunicationList = pwCategoryPanel.FindControl( "rptCommunicationLists" ) as Repeater;
+
+                if ( showCategory )
+                {
+                    pwCategoryPanel.Title = category.Name;
+                    pwCategoryPanel.TitleIconCssClass = category.IconCssClass;
+                }
+                else
+                {
+                    var pnlListRepeaterParent = e.Item.FindControl( "pnlListRepeaterParent" ) as Panel;
+                    pwCategoryPanel.Controls.Remove( rptCommunicationList );
+                    pnlListRepeaterParent.Controls.Add( rptCommunicationList );
+                    pwCategoryPanel.Visible = false;
+                }
+
+                rptCommunicationList.DataSource = GetListsByCategory( category );
+                rptCommunicationList.DataBind();
+            }
+        }
+
+        private List<Group> GetListsByCategory( Category category )
+        {
+            int communicationListGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_COMMUNICATIONLIST.AsGuid() ).Id;
+            int? communicationListGroupTypeDefaultRoleId = GroupTypeCache.Get( communicationListGroupTypeId ).DefaultGroupRoleId;
+
+            var rockContext = new RockContext();
+
+            var memberOfList = new GroupMemberService( rockContext ).GetByPersonId( CurrentPersonId.Value ).AsNoTracking().Select( a => a.GroupId ).ToList();
+
+            // Get a list of syncs for the communication list groups where the default role is sync'd AND the current person is NOT a member of
+            // This is used to filter out the list of communication lists.
+            var commGroupSyncsForDefaultRole = new GroupSyncService( rockContext )
+                .Queryable()
+                .Where( a => a.Group.GroupTypeId == communicationListGroupTypeId )
+                .Where( a => a.GroupTypeRoleId == communicationListGroupTypeDefaultRoleId )
+                .Where( a => !memberOfList.Contains( a.GroupId ) )
+                .Select( a => a.GroupId )
+                .ToList();
+
+            var communicationLists = new GroupService( rockContext )
+               .Queryable()
+               .Where( a => a.GroupTypeId == communicationListGroupTypeId && !commGroupSyncsForDefaultRole.Contains( a.Id ) )
+               .IsActive()
+               .ToList();
+
+            var categoryGuids = new List<Guid>();
+            categoryGuids.Add( category.Guid );
+            var viewableCommunicationLists = new List<Group>();
+
+            foreach ( var communicationList in communicationLists )
+            {
+                communicationList.LoadAttributes( rockContext );
+                if ( !categoryGuids.Any() )
+                {
+                    // if no categories where specified, only show lists that the person has VIEW auth
+                    if ( communicationList.IsAuthorized( Rock.Security.Authorization.VIEW, this.CurrentPerson ) )
+                    {
+                        viewableCommunicationLists.Add( communicationList );
+                    }
+                }
+                else
+                {
+                    Guid? categoryGuid = communicationList.GetAttributeValue( "Category" ).AsGuidOrNull();
+                    if ( categoryGuid.HasValue && categoryGuids.Contains( categoryGuid.Value ) )
+                    {
+                        viewableCommunicationLists.Add( communicationList );
+                    }
+                }
+            }
+
+            viewableCommunicationLists = viewableCommunicationLists.OrderBy( a =>
+            {
+                var name = a.GetAttributeValue( "PublicName" );
+                if ( name.IsNullOrWhiteSpace() )
+                {
+                    name = a.Name;
+                }
+
+                return name;
+            } ).ToList();
+
+            var groupIds = viewableCommunicationLists.Select( a => a.Id ).ToList();
+            var personId = this.CurrentPersonId.Value;
+
+            showMediumPreference = this.GetAttributeValue( AttributeKey.ShowMediumPreference ).AsBoolean();
+
+            personCommunicationListsMember = new GroupMemberService( rockContext )
+                .Queryable()
+                .AsNoTracking()
+                .Where( a => groupIds.Contains( a.GroupId ) && a.PersonId == personId )
+                .GroupBy( a => a.GroupId )
+                .ToList()
+                .ToDictionary( k => k.Key, v => v.FirstOrDefault() );
+
+            //nbNoCommunicationLists.Visible = !viewableCommunicationLists.Any();
+            pnlCommunicationPreferences.Visible = viewableCommunicationLists.Any();
+
+            return viewableCommunicationLists;
+
+        }
+
+        /// <summary>
+        /// Handles the CheckedChanged event of the cbCommunicationListIsSubscribed control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void cbCommunicationListIsSubscribed_CheckedChanged( object sender, EventArgs e )
+        {
+            var repeaterItem = ( sender as RockCheckBox ).BindingContainer as RepeaterItem;
+            SaveChanges( repeaterItem );
+        }
+
+        /// <summary>
+        /// Handles the CheckedChanged event of the tglCommunicationPreference control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void tglCommunicationPreference_CheckedChanged( object sender, EventArgs e )
+        {
+            var repeaterItem = ( sender as Toggle ).BindingContainer as RepeaterItem;
+            SaveChanges( repeaterItem );
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Saves the changes.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        protected void SaveChanges( RepeaterItem item )
+        {
+            var hfGroupId = item.FindControl( "hfGroupId" ) as HiddenField;
+            var cbCommunicationListIsSubscribed = item.FindControl( "cbCommunicationListIsSubscribed" ) as RockCheckBox;
+            var tglCommunicationPreference = item.FindControl( "tglCommunicationPreference" ) as Toggle;
+            var nbGroupNotification = item.FindControl( "nbGroupNotification" ) as NotificationBox;
+            nbGroupNotification.Visible = false;
+
+            using ( var rockContext = new RockContext() )
+            {
+                int groupId = hfGroupId.Value.AsInteger();
+                var groupMemberService = new GroupMemberService( rockContext );
+                var group = new GroupService( rockContext ).Get( groupId );
+                var groupMemberRecordsForPerson = groupMemberService.Queryable().Where( a => a.GroupId == groupId && a.PersonId == this.CurrentPersonId ).ToList();
+                if ( groupMemberRecordsForPerson.Any() )
+                {
+                    // normally there would be at most 1 group member record for the person, but just in case, mark them all
+                    foreach ( var groupMember in groupMemberRecordsForPerson )
+                    {
+                        if ( cbCommunicationListIsSubscribed.Checked )
+                        {
+                            if ( groupMember.GroupMemberStatus == GroupMemberStatus.Inactive )
+                            {
+                                groupMember.GroupMemberStatus = GroupMemberStatus.Active;
+                                if ( groupMember.Note == "Unsubscribed" )
+                                {
+                                    groupMember.Note = string.Empty;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if ( groupMember.GroupMemberStatus == GroupMemberStatus.Active )
+                            {
+                                groupMember.GroupMemberStatus = GroupMemberStatus.Inactive;
+                                if ( groupMember.Note.IsNullOrWhiteSpace() )
+                                {
+                                    groupMember.Note = "Unsubscribed";
+                                }
+                            }
+                        }
+
+                        CommunicationType communicationType = tglCommunicationPreference.Checked ? CommunicationType.Email : CommunicationType.SMS;
+                        groupMember.CommunicationPreference = communicationType;
+                    }
+                }
+                else
+                {
+                    // they are not currently in the Group
+                    if ( cbCommunicationListIsSubscribed.Checked )
+                    {
+                        var groupMember = new GroupMember();
+                        groupMember.PersonId = this.CurrentPersonId.Value;
+                        groupMember.GroupId = group.Id;
+                        int? defaultGroupRoleId = GroupTypeCache.Get( group.GroupTypeId ).DefaultGroupRoleId;
+                        if ( defaultGroupRoleId.HasValue )
+                        {
+                            groupMember.GroupRoleId = defaultGroupRoleId.Value;
+                        }
+                        else
+                        {
+                            nbGroupNotification.Text = "Unable to add to group.";
+                            nbGroupNotification.Details = "Group has no default group role";
+                            nbGroupNotification.NotificationBoxType = NotificationBoxType.Danger;
+                            nbGroupNotification.Visible = true;
+                        }
+
+                        groupMember.GroupMemberStatus = GroupMemberStatus.Active;
+                        CommunicationType communicationType = tglCommunicationPreference.Checked ? CommunicationType.Email : CommunicationType.SMS;
+                        groupMember.CommunicationPreference = communicationType;
+
+                        if ( groupMember.IsValidGroupMember( rockContext ) )
+                        {
+                            groupMemberService.Add( groupMember );
+                            rockContext.SaveChanges();
+                        }
+                        else
+                        {
+                            // if the group member couldn't be added (for example, one of the group membership rules didn't pass), add the validation messages to the errormessages
+                            nbGroupNotification.Text = "Unable to add to group.";
+                            nbGroupNotification.Details = groupMember.ValidationResults.Select( a => a.ErrorMessage ).ToList().AsDelimited( "<br />" );
+                            nbGroupNotification.NotificationBoxType = NotificationBoxType.Danger;
+                            nbGroupNotification.Visible = true;
+                        }
+                    }
+                }
+
+                rockContext.SaveChanges();
+            }
+        }
+
+
+        /// <summary>
+        /// Binds the repeater.
+        /// </summary>
+        protected void BindRepeater()
+        {
+            if ( this.CurrentPersonId == null )
+            {
+                return;
+            }
+
+            var rockContext = new RockContext();
+
+            var categoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategories ).SplitDelimitedValues().AsGuidList();
+
+            var categories = new CategoryService( rockContext ).GetByGuids( categoryGuids ).OrderBy( c => c.Name ).ToList();
+
+            rptCommunicationListCategories.DataSource = categories;
+            rptCommunicationListCategories.DataBind();
+        }
+
+        #endregion
+    }
+}

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -13,28 +13,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+//
+// <notice>
+// This file contains modifications by Kingdom First Solutions
+// and is a derivative work.
+//
+// Modification (including but not limited to):
+// * Adds ability display list categories
+// </notice>
+//
 
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-
 using Rock;
+using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
 using Rock.Web.Cache;
-using Rock.Web.UI.Controls;
-using Rock.Attribute;
 using Rock.Web.UI;
-using System.Data.Entity;
+using Rock.Web.UI.Controls;
 
 namespace RockWeb.Plugins.rocks_kfs.Communication
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [DisplayName( "Communication List Subscribe" )]
     [Category( "KFS > Communication" )]
@@ -64,7 +71,9 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         Key = AttributeKey.ShowCommunicationListCategories,
         Order = 3
         )]
+
     #endregion Block Attributes
+
     public partial class CommunicationListSubscribe : RockBlock
     {
         #region Attribute Keys
@@ -93,7 +102,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         /// </summary>
         private bool showMediumPreference = true;
 
-        #endregion
+        #endregion fields
 
         #region Base Control Methods
 
@@ -124,7 +133,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             }
         }
 
-        #endregion
+        #endregion Base Control Methods
 
         #region Events
 
@@ -176,7 +185,6 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 var tglCommunicationPreference = e.Item.FindControl( "tglCommunicationPreference" ) as Toggle;
                 tglCommunicationPreference.Checked = communicationType == CommunicationType.Email;
                 tglCommunicationPreference.Visible = showMediumPreference;
-
             }
         }
 
@@ -212,6 +220,11 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             }
         }
 
+        /// <summary>
+        /// Gets the lists by category.
+        /// </summary>
+        /// <param name="category">The category.</param>
+        /// <returns></returns>
         private List<Group> GetListsByCategory( Category category )
         {
             int communicationListGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_COMMUNICATIONLIST.AsGuid() ).Id;
@@ -286,11 +299,10 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 .ToList()
                 .ToDictionary( k => k.Key, v => v.FirstOrDefault() );
 
-            //nbNoCommunicationLists.Visible = !viewableCommunicationLists.Any();
+            nbNoCommunicationLists.Visible = !viewableCommunicationLists.Any();
             pnlCommunicationPreferences.Visible = viewableCommunicationLists.Any();
 
-            return viewableCommunicationLists;
-
+            return viewableCommunicationLists.OrderBy( l => l.Order ).ThenBy( l => l.Name ).ToList();
         }
 
         /// <summary>
@@ -315,7 +327,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             SaveChanges( repeaterItem );
         }
 
-        #endregion
+        #endregion Events
 
         #region Methods
 
@@ -414,7 +426,6 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             }
         }
 
-
         /// <summary>
         /// Binds the repeater.
         /// </summary>
@@ -429,12 +440,12 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
 
             var categoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategories ).SplitDelimitedValues().AsGuidList();
 
-            var categories = new CategoryService( rockContext ).GetByGuids( categoryGuids ).OrderBy( c => c.Name ).ToList();
+            var categories = new CategoryService( rockContext ).GetByGuids( categoryGuids ).OrderBy( c => c.Order ).ThenBy( c => c.Name ).ToList();
 
             rptCommunicationListCategories.DataSource = categories;
             rptCommunicationListCategories.DataBind();
         }
 
-        #endregion
+        #endregion Methods
     }
 }

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -475,7 +475,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 {
                     lists.AddRange( GetListsByCategory( category ) );
                 }
-                rptCommunicationListsNoCategories.DataSource = lists;
+                rptCommunicationListsNoCategories.DataSource = lists.OrderBy( g => g.Name );
                 rptCommunicationListsNoCategories.DataBind();
             }
         }

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -334,11 +334,10 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 .ToList()
                 .ToDictionary( k => k.Key, v => v.FirstOrDefault() );
 
-            if(localPersonCommunicationListsMember != null )
+            if ( localPersonCommunicationListsMember != null )
             {
                 personCommunicationListsMember.AddRange( localPersonCommunicationListsMember );
             }
-            
 
             nbNoCommunicationLists.Visible = !viewableCommunicationLists.Any();
             pnlCommunicationPreferences.Visible = viewableCommunicationLists.Any();

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -19,7 +19,7 @@
 // and is a derivative work.
 //
 // Modification (including but not limited to):
-// * Adds ability display list categories
+// * Adds ability to display list categories
 // </notice>
 //
 


### PR DESCRIPTION
### Description 

Adds a new block that allows for the display of communication lists grouped by category. Preserves default display if not configured to display by category. Based on the Communication List Subscribe Block

##### What does the change add or fix?

New Block based on the Communication List Subscribe block.

**New Settings:**

* Show List Categories

---------

### Release Notes 

* Added ability to show communication lists grouped by category.

---------

### Requested By

VCC

---------

### Screenshots

![image](https://user-images.githubusercontent.com/2577926/127396413-df1631fe-8bb7-484e-85ba-28eb14c1c11e.png)

![image](https://user-images.githubusercontent.com/2577926/127396434-cc2093ed-a4e2-470f-8e29-0849d060f311.png)


---------

### Change Log

* Communication/CommunicationListSubscribe.ascx - Added dom
* Communication/CommunicationListSubscribe.ascx.cs - Added processing code behind

---------

### Migrations/External Impacts

No, new block.
