### PR TITLE
Fix for group finder not supporting full 10 digit zip codes

### DIFF
--- a/Groups/GroupFinder.ascx
+++ b/Groups/GroupFinder.ascx
@@ -35,7 +35,7 @@
 
                         <Rock:AddressControl ID="acAddress" runat="server" Required="true" RequiredErrorMessage="Your Address is Required" />
                         <Rock:RockTextBox ID="tbPostalCode" runat="server" Required="true" RequiredErrorMessage="Your Postal Code is Required" Label="Postal Code" CssClass="form-control js-postal-code js-postcode js-address-field" />
-                        <asp:RegularExpressionValidator ID="revPostalCode" runat="server" ControlToValidate="tbPostalCode" ValidationExpression="[0-9]*\-*[0-9]*" ErrorMessage="Your Postal code is an invalid format, 12345 or 12345-6789 only." Text="-" CssClass="hidden hide"></asp:RegularExpressionValidator>
+                        <asp:RegularExpressionValidator ID="revPostalCode" runat="server" ControlToValidate="tbPostalCode" ValidationExpression="[0-9]*\-*[0-9]*" Text="-" CssClass="hidden hide"></asp:RegularExpressionValidator>
                         <Rock:RockCheckBoxList ID="cblCampus" runat="server" Label="Campuses" DataTextField="Name" DataValueField="Id" RepeatDirection="Horizontal" Visible="false" />
                         <Rock:RockDropDownList ID="ddlCampus" runat="server" Label="Campus" DataTextField="Name" DataValueField="Id" Visible="false" />
                         <asp:PlaceHolder ID="phFilterControls" runat="server" />

--- a/Groups/GroupFinder.ascx
+++ b/Groups/GroupFinder.ascx
@@ -34,7 +34,8 @@
                         <asp:ValidationSummary ID="valSummary" runat="server" HeaderText="Please correct the following:" CssClass="alert alert-validation" />
 
                         <Rock:AddressControl ID="acAddress" runat="server" Required="true" RequiredErrorMessage="Your Address is Required" />
-                        <Rock:NumberBox ID="nbPostalCode" runat="server" Required="true" RequiredErrorMessage="Your Postal Code is Required" Label="Postal Code" />
+                        <Rock:RockTextBox ID="tbPostalCode" runat="server" Required="true" RequiredErrorMessage="Your Postal Code is Required" Label="Postal Code" CssClass="form-control js-postal-code js-postcode js-address-field" />
+                        <asp:RegularExpressionValidator ID="revPostalCode" runat="server" ControlToValidate="tbPostalCode" ValidationExpression="[0-9]*\-*[0-9]*" ErrorMessage="Your Postal code is an invalid format, 12345 or 12345-6789 only." Text="-" CssClass="hidden hide"></asp:RegularExpressionValidator>
                         <Rock:RockCheckBoxList ID="cblCampus" runat="server" Label="Campuses" DataTextField="Name" DataValueField="Id" RepeatDirection="Horizontal" Visible="false" />
                         <Rock:RockDropDownList ID="ddlCampus" runat="server" Label="Campus" DataTextField="Name" DataValueField="Id" Visible="false" />
                         <asp:PlaceHolder ID="phFilterControls" runat="server" />

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -367,7 +367,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
 
                 if ( !string.IsNullOrWhiteSpace( postalcodePageParam ) )
                 {
-                    nbPostalCode.Text = postalcodePageParam.AsNumeric();
+                    tbPostalCode.Text = postalcodePageParam;
                 }
 
                 if ( _targetPersonGuid != Guid.Empty )
@@ -516,7 +516,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
         protected void btnClear_Click( object sender, EventArgs e )
         {
             acAddress.SetValues( null );
-            nbPostalCode.Text = "";
+            tbPostalCode.Text = "";
             BuildDynamicControls();
 
             pnlSearch.CssClass = "";
@@ -828,7 +828,8 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             if ( fenceTypeGuid.HasValue || GetAttributeValue( "ShowProximity" ).AsBoolean() )
             {
                 acAddress.Visible = !GetAttributeValue( "EnablePostalCodeSearch" ).AsBoolean();
-                nbPostalCode.Visible = GetAttributeValue( "EnablePostalCodeSearch" ).AsBoolean();
+                tbPostalCode.Visible = GetAttributeValue( "EnablePostalCodeSearch" ).AsBoolean();
+                revPostalCode.Enabled = GetAttributeValue( "EnablePostalCodeSearch" ).AsBoolean();
 
                 if ( CurrentPerson != null )
                 {
@@ -836,7 +837,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     acAddress.SetValues( currentPersonLocation );
                     if ( currentPersonLocation != null )
                     {
-                        nbPostalCode.Text = currentPersonLocation.PostalCode;
+                        tbPostalCode.Text = currentPersonLocation.PostalCode;
                     }
                 }
 
@@ -846,7 +847,8 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             else
             {
                 acAddress.Visible = false;
-                nbPostalCode.Visible = false;
+                tbPostalCode.Visible = false;
+                revPostalCode.Visible = false;
 
                 // Check to see if there's any filters
                 string scheduleFilters = GetAttributeValue( "ScheduleFilters" );
@@ -928,12 +930,13 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 phFilterControlsCollapsed.Controls.Clear();
             }
 
-            nbPostalCode.Label = GetAttributeValue( "PostalCodeLabel" );
-            nbPostalCode.RequiredErrorMessage = string.Format( "Your {0} is Required", GetAttributeValue( "PostalCodeLabel" ) );
+            tbPostalCode.Label = GetAttributeValue( "PostalCodeLabel" );
+            tbPostalCode.RequiredErrorMessage = string.Format( "Your {0} is Required", GetAttributeValue( "PostalCodeLabel" ) );
+            revPostalCode.ErrorMessage = string.Format( "Your {0} is an invalid format, 12345 or 12345-6789 only.", GetAttributeValue( "PostalCodeLabel" ) );
             if ( hideFilters.Contains( "filter_postalcode" ) )
             {
-                pnlSearch.Controls.Remove( nbPostalCode );
-                phFilterControlsCollapsed.Controls.Add( nbPostalCode );
+                pnlSearch.Controls.Remove( tbPostalCode );
+                phFilterControlsCollapsed.Controls.Add( tbPostalCode );
             }
 
             var scheduleFilters = GetAttributeValue( "ScheduleFilters" ).SplitDelimitedValues().ToList();
@@ -1438,10 +1441,10 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
 
                     if ( GetAttributeValue( "EnablePostalCodeSearch" ).AsBoolean() )
                     {
-                        if ( !string.IsNullOrWhiteSpace( nbPostalCode.Text ) )
+                        if ( !string.IsNullOrWhiteSpace( tbPostalCode.Text ) )
                         {
                             mapCoordinate = new LocationService( rockContext )
-                                .GetMapCoordinateFromPostalCode( nbPostalCode.Text );
+                                .GetMapCoordinateFromPostalCode( tbPostalCode.Text );
                         }
                     }
                     else
@@ -1462,7 +1465,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                             personLocation = new LocationService( rockContext ).Get( ( int ) campusLocation );
                             if ( !string.IsNullOrWhiteSpace( personLocation.PostalCode ) )
                             {
-                                nbPostalCode.Text = personLocation.PostalCode.Substring( 0, 5 );
+                                tbPostalCode.Text = personLocation.PostalCode.Substring( 0, 5 );
                             }
                             if ( personLocation.GeoPoint != null )
                                 mapCoordinate = new MapCoordinate( personLocation.Latitude, personLocation.Longitude );
@@ -1501,7 +1504,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
     </div>
 </div>
 ",
-                        nbPostalCode.Text );
+                        tbPostalCode.Text );
 
                     personMapItem = new FinderMapItem();
                     personMapItem.Name = "Your Location";


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Convert postal code to Textbox to support 10 digit zip code.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Convert postal code to Textbox to support 10 digit zip code.

---------

### Requested By

##### Who reported, requested, or paid for the change?

OHC

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/128063817-89029726-9ead-415e-a787-a4ce0c2d2b96.png)

![image](https://user-images.githubusercontent.com/2990519/128063834-5241fbf4-e7cd-46e5-aa49-ec121f2a11e3.png)

---------

### Change Log

##### What files does it affect?

- Groups/GroupFinder.ascx
- Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
