### PR TITLE
Communication List Categories Expanded Block Setting

### DIFF
--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -166,7 +166,6 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         protected void rptCommunicationListCategories_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
             var category = e.Item.DataItem as Rock.Model.Category;
-            var showCategory = this.GetAttributeValue( AttributeKey.ShowCommunicationListCategories ).AsBoolean();
             if ( category != null )
             {
                 var pwCategoryPanel = e.Item.FindControl( "pwCategoryPanel" ) as PanelWidget;

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -72,6 +72,14 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         Key = AttributeKey.ShowCommunicationListCategories,
         Order = 3
         )]
+    [GroupCategoryField(
+        "Communication List Categories Default Opened",
+        Description = "By default all categories are displayed collapsed. Select the categories of the communication lists to display uncollapsed (open).",
+        AllowMultiple = true,
+        GroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_COMMUNICATIONLIST,
+        IsRequired = false,
+        Key = AttributeKey.CommunicationListCategoriesOpen,
+        Order = 4 )]
 
     #endregion Block Attributes
 
@@ -87,6 +95,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             public const string CommunicationListCategories = "CommunicationListCategories";
             public const string ShowMediumPreference = "ShowMediumPreference";
             public const string ShowCommunicationListCategories = "ShowCommunicationListCategories";
+            public const string CommunicationListCategoriesOpen = "CommunicationListCategoriesOpen";
         }
 
         #endregion Attribute Keys
@@ -169,7 +178,9 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             if ( category != null )
             {
                 var pwCategoryPanel = e.Item.FindControl( "pwCategoryPanel" ) as PanelWidget;
+                var openCategoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategoriesOpen ).SplitDelimitedValues().AsGuidList();
 
+                pwCategoryPanel.Expanded = openCategoryGuids.Contains( category.Guid );
                 pwCategoryPanel.Title = category.Name;
                 pwCategoryPanel.TitleIconCssClass = category.IconCssClass;
                 var rptCommunicationLists = pwCategoryPanel.FindControl( "rptCommunicationLists" ) as Repeater;

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -73,12 +73,12 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         Order = 3
         )]
     [GroupCategoryField(
-        "Communication List Categories Default Opened",
-        Description = "By default all categories are displayed collapsed. Select the categories of the communication lists to display uncollapsed (open).",
+        "Communication List Categories Default Expanded",
+        Description = "By default all categories are displayed collapsed. Select the categories of the communication lists to display expanded (open).",
         AllowMultiple = true,
         GroupTypeGuid = Rock.SystemGuid.GroupType.GROUPTYPE_COMMUNICATIONLIST,
         IsRequired = false,
-        Key = AttributeKey.CommunicationListCategoriesOpen,
+        Key = AttributeKey.CommunicationListCategoriesExpanded,
         Order = 4 )]
 
     #endregion Block Attributes
@@ -95,7 +95,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             public const string CommunicationListCategories = "CommunicationListCategories";
             public const string ShowMediumPreference = "ShowMediumPreference";
             public const string ShowCommunicationListCategories = "ShowCommunicationListCategories";
-            public const string CommunicationListCategoriesOpen = "CommunicationListCategoriesOpen";
+            public const string CommunicationListCategoriesExpanded = "CommunicationListCategoriesOpen";
         }
 
         #endregion Attribute Keys
@@ -178,7 +178,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             if ( category != null )
             {
                 var pwCategoryPanel = e.Item.FindControl( "pwCategoryPanel" ) as PanelWidget;
-                var openCategoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategoriesOpen ).SplitDelimitedValues().AsGuidList();
+                var openCategoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategoriesExpanded ).SplitDelimitedValues().AsGuidList();
 
                 pwCategoryPanel.Expanded = openCategoryGuids.Contains( category.Guid );
                 pwCategoryPanel.Title = category.Name;


### PR DESCRIPTION
### Description 

Added setting that allows category to be either collapsed or expanded by default.

**New Settings:**

* Communication List Categories Default Expanded

---------

### Release Notes 

* Added ability for list categories to be expanded by default.

---------

### Requested By

Venture

---------

### Screenshots

![image](https://user-images.githubusercontent.com/2577926/129603236-8504e070-83af-46ea-9168-add544932249.png)


---------

### Change Log

* Communication/CommunicationListSubscribe.ascx.cs - Added module setting and removed unnecessary declaration

---------

### Migrations/External Impacts

None.
