### PR TITLE
Check-in Display Messages Block

### DIFF
--- a/CheckIn/DisplayMessages.ascx
+++ b/CheckIn/DisplayMessages.ascx
@@ -1,0 +1,8 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="DisplayMessages.ascx.cs" Inherits="RockWeb.Plugins.rocks_kfs.CheckIn.DisplayMessages" %>
+<asp:UpdatePanel ID="upContent" runat="server">
+<ContentTemplate>
+
+    <Rock:ModalAlert ID="maWarning" runat="server" />
+
+</ContentTemplate>
+</asp:UpdatePanel>

--- a/CheckIn/DisplayMessages.ascx.cs
+++ b/CheckIn/DisplayMessages.ascx.cs
@@ -1,0 +1,184 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.Entity;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using System.Web;
+using System.Web.UI;
+using System.Web.UI.HtmlControls;
+
+using Rock;
+using Rock.Attribute;
+using Rock.CheckIn;
+using Rock.Data;
+using Rock.Model;
+using Rock.Utility;
+using Rock.Web.UI;
+
+namespace RockWeb.Plugins.rocks_kfs.CheckIn
+{
+    /// <summary>
+    ///
+    /// </summary>
+    [DisplayName( "Display Messages" )]
+    [Category( "KFS > Check-in" )]
+    [Description( "Displays the check-in state messages." )]
+
+    #region Block Attributes
+
+    [LavaField( "Detail Message",
+        Key = AttributeKey.DetailMessage,
+        Description = "You can customize the message even further using lava, an array of 'Messages' is available to use what was provided from the current check-in state.",
+        IsRequired = false,
+        DefaultValue = "" )]
+
+    [CustomDropdownListField( "Type of Alert Box",
+        Key = AttributeKey.TypeOfAlert,
+        Description = "Select the type of alert box to show the messages in. ('Log only' found in ServiceLog table)",
+        ListSource = "-3^None,-2^Log Only,-1^Append to Existing,0^Alert,1^Information,2^Warning,3^No Heading",
+        DefaultValue = "-3" )]
+
+    #endregion Block Attributes
+
+    public partial class DisplayMessages : CheckInBlock
+    {
+        /* 2021-05/07 ETD
+         * Use new here because the parent CheckInBlock also has inherited class AttributeKey.
+         */
+        private new static class AttributeKey
+        {
+            public const string DetailMessage = "DetailMessage";
+            public const string TypeOfAlert = "TypeOfAlert";
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            if ( CurrentWorkflow == null || CurrentCheckInState == null )
+            {
+                NavigateToHomePage();
+            }
+            else
+            {
+                if ( Page.IsPostBack )
+                {
+                    try
+                    {
+                        string detailMsg = GetAttributeValue( AttributeKey.DetailMessage );
+                        int? typeOfAlert = GetAttributeValue( AttributeKey.TypeOfAlert ).AsIntegerOrNull();
+
+                        var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, null, new Rock.Lava.CommonMergeFieldsOptions { GetLegacyGlobalMergeFields = false } );
+                        mergeFields.Add( "CurrentFamily", CurrentCheckInState.CheckIn.CurrentFamily );
+                        mergeFields.Add( "Families", CurrentCheckInState.CheckIn.Families );
+                        mergeFields.Add( "CheckinCurrentPerson", CurrentCheckInState.CheckIn.CurrentPerson );
+                        mergeFields.Add( "Kiosk", CurrentCheckInState.Kiosk );
+                        mergeFields.Add( "RegistrationModeEnabled", CurrentCheckInState.Kiosk.RegistrationModeEnabled );
+                        mergeFields.Add( "Messages", CurrentCheckInState.Messages );
+
+                        if ( CurrentCheckInState.Messages.Count > 0 )
+                        {
+                            var messageStr = "";
+                            foreach ( var message in CurrentCheckInState.Messages )
+                            {
+                                if ( message.MessageText.IsNotNullOrWhiteSpace() )
+                                {
+                                    messageStr += message.MessageText;
+                                }
+                            }
+
+                            if ( messageStr.IsNotNullOrWhiteSpace() )
+                            {
+                                if ( detailMsg.IsNotNullOrWhiteSpace() )
+                                {
+                                    messageStr = detailMsg.ResolveMergeFields( mergeFields );
+                                }
+                                messageStr = messageStr.RemoveCrLf();
+                                if ( typeOfAlert.HasValue && typeOfAlert.Value >= 0 )
+                                {
+                                    maWarning.Show( messageStr, ( Rock.Web.UI.Controls.ModalAlertType ) typeOfAlert.Value );
+                                }
+                                else if ( typeOfAlert.HasValue )
+                                {
+                                    switch ( typeOfAlert.Value )
+                                    {
+                                        case -2:
+                                            LogEvent( null, "LogMessages", messageStr, string.Format( "Message Count: {0}", CurrentCheckInState.Messages.Count.ToString() ) );
+                                            break;
+                                        case -1:
+                                            var script = $"$('.bootbox-body').append('{messageStr}');";
+                                            ScriptManager.RegisterStartupScript( this, this.GetType(), "DisplayMessages", script, true );
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                }
+                            }
+                            CurrentCheckInState.Messages.Clear();
+                        }
+
+                    }
+                    catch ( Exception ex )
+                    {
+                        LogException( ex );
+                    }
+                }
+            }
+        }
+
+        private static ServiceLog LogEvent( RockContext rockContext, string type, string input, string result )
+        {
+            if ( rockContext == null )
+            {
+                rockContext = new RockContext();
+            }
+            var rockLogger = new ServiceLogService( rockContext );
+            ServiceLog serviceLog = new ServiceLog
+            {
+                Name = "KFS Check-in - Display Messages",
+                Type = type,
+                LogDateTime = RockDateTime.Now,
+                Input = input,
+                Result = result,
+                Success = true
+            };
+            rockLogger.Add( serviceLog );
+            rockContext.SaveChanges();
+            return serviceLog;
+        }
+
+
+    }
+}

--- a/CheckIn/DisplayMessages.ascx.cs
+++ b/CheckIn/DisplayMessages.ascx.cs
@@ -47,7 +47,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
 
     [LavaField( "Detail Message",
         Key = AttributeKey.DetailMessage,
-        Description = "You can customize the message even further using lava, an array of 'Messages' is available to use what was provided from the current check-in state.",
+        Description = "By default the messages will come straight from the check-in state 'Messages' array. You can customize the message even further using lava, an array of 'Messages' is available to use what was provided from the current check-in state.",
         IsRequired = false,
         DefaultValue = "" )]
 
@@ -113,7 +113,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
                             var messageStr = "";
                             foreach ( var message in CurrentCheckInState.Messages )
                             {
-                                if ( message.MessageText.IsNotNullOrWhiteSpace() )
+                                if ( message.MessageText.IsNotNullOrWhiteSpace() && !messageStr.Contains( message.MessageText ) )
                                 {
                                     messageStr += message.MessageText;
                                 }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Created Display Messages block to be able to load check-in state messages and log or display them to the user.
- Must be added where needed, such as Family Select page and Person Select (Family Check-in) page.

**New Settings:**

- _Detail Message_, By default the messages will come straight from the check-in state 'Messages' array. You can customize the message even further using lava, an array of 'Messages' is available to use what was provided from the current check-in state.
- _Type of Alert_, Select the type of alert box to show the messages in. ('Log only' found in ServiceLog table)
- _Process Messages on Postback Only_, Process messages on page load every time (false) or only on postback (true)?
- _Clear Messages on Display_ When the message gets displayed or logged, clear the check-in state messages. In the event you want the messages to stick through multiple actions, disable this.
- _Append to Container_, jQuery selector of the tag you would like to append your message to.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added new "Display Messages" check-in block to log or display check-in state messages.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Kensington and Venture

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/142477907-2098f506-e8fb-4177-91c2-5ae698ecc7a4.png)

![image](https://user-images.githubusercontent.com/2990519/139154137-1d85a123-b0d6-4be5-ad9e-3e98368ca7dc.png)

Example of customized messages:   
<img width="850" alt="Screenshot 2021-11-05 103221" src="https://user-images.githubusercontent.com/2990519/140549867-2af8c8ff-6905-4981-b2a8-27dab5deb695.png">

<img width="844" alt="Screenshot 2021-11-05 103517" src="https://user-images.githubusercontent.com/2990519/140549871-c229a170-2a72-439a-999d-b82f4efdcf68.png">


---------

### Change Log

##### What files does it affect?

- CheckIn/DisplayMessages.ascx
- CheckIn/DisplayMessages.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Though it can run without it, primarily designed to be used in conjunction with https://github.com/KingdomFirst/RockAssemblies/pull/49
