### PR TITLE
Steps To Care - Missed "Convert To" updates.

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -202,7 +202,7 @@
                 <Rock:NoteContainer ID="notesTimeline" runat="server" ShowHeading="false"></Rock:NoteContainer>
             </Content>
         </Rock:ModalDialog>
-        <Rock:ModalDialog ID="mdConnectionRequest" runat="server" Title="Convert to Connection Request" ValidationGroup="ConnectionRequest" ClickBackdropToClose="true" OnSaveClick="mdConnectionRequest_SaveClick" SaveButtonCausesValidation="true" Content-CssClass="modal-kfsconnectionrequest">
+        <Rock:ModalDialog ID="mdConnectionRequest" runat="server" Title="Add Connection Request" ValidationGroup="ConnectionRequest" ClickBackdropToClose="true" OnSaveClick="mdConnectionRequest_SaveClick" SaveButtonCausesValidation="true" Content-CssClass="modal-kfsconnectionrequest">
             <Content>
                 <asp:HiddenField ID="hfConnectionCareNeedId" runat="server" />
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -125,8 +125,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.BenevolenceDetailPage )]
 
     [BooleanField(
-        "Enable Convert to Connection Request",
-        Description = "Enable Convert to Connection Request Action",
+        "Enable Add Connection Request",
+        Description = "Enable Add Connection Request Action",
         IsRequired = false,
         DefaultBooleanValue = false,
         Order = 10,


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Missed two phrases of "Convert To" changing to "Add"

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Missed two phrases of "Convert To" changing to "Add"

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/145457487-ef587ba8-2e68-4c40-b583-14a83b1869f5.png)

![image](https://user-images.githubusercontent.com/2990519/145457555-3a416ef8-10d1-44df-bda3-3cdc3eb9dd60.png)

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
