### PR TITLE
Steps to Care Family/Sub Needs

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -23,6 +23,26 @@
     .popover-content {
         text-align: center;
     }
+
+    .hasParentNeed {
+        background-color: #e6e6e6 !important;
+    }
+
+    .table-striped > tbody > tr.assigned.hasParentNeed:nth-of-type(odd) {
+        background-color: oldlace !important;
+    }
+
+    .table-striped > tbody > tr.assigned.hasParentNeed:nth-of-type(even) {
+        background-color: #fff2da !important;
+    }
+
+    .grid-select-cell .photo-icon {
+        margin-bottom: 8px;
+    }
+
+    .grid-select-cell.photo-icon-cell {
+        padding-bottom: 8px;
+    }
 </style>
 <asp:UpdatePanel runat="server" ID="upnlCareDashboard" UpdateMode="Always">
     <ContentTemplate>
@@ -87,7 +107,7 @@
                         <Rock:Grid ID="gList" runat="server" DisplayType="Full" AllowSorting="true" ExportSource="DataSource">
                             <Columns>
                                 <Rock:ColorField DataField="Category.AttributeValues.Color" ToolTipDataField="Category.Value" HeaderText="Cat" SortExpression="Category.Value" />
-                                <Rock:RockTemplateField SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName, LastName, FirstName" HeaderText="Name">
+                                <Rock:RockTemplateField SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName, LastName, FirstName" HeaderText="Name" ItemStyle-CssClass="text-nowrap">
                                     <ItemTemplate>
                                         <asp:Literal ID="lName" runat="server" />
                                     </ItemTemplate>
@@ -100,7 +120,7 @@
                                         <asp:Literal ID="lCareTouches" runat="server"></asp:Literal>
                                     </ItemTemplate>
                                 </Rock:RockTemplateField>
-                                <Rock:RockTemplateField HeaderText="Assigned" SortExpression="AssignedPersons">
+                                <Rock:RockTemplateField HeaderText="Assigned" SortExpression="AssignedPersons" ItemStyle-CssClass="photo-icon-cell align-middle">
                                     <ItemTemplate>
                                         <asp:Literal ID="lAssigned" runat="server"></asp:Literal>
                                     </ItemTemplate>
@@ -124,7 +144,7 @@
                         <Rock:Grid ID="gFollowUp" runat="server" DisplayType="Full" AllowSorting="true" ExportSource="DataSource">
                             <Columns>
                                 <Rock:ColorField DataField="Category.AttributeValues.Color" ToolTipDataField="Category.Value" HeaderText="Cat" SortExpression="Category.Value" />
-                                <Rock:RockTemplateField SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName, LastName, FirstName" HeaderText="Name">
+                                <Rock:RockTemplateField SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName, LastName, FirstName" HeaderText="Name" ItemStyle-CssClass="text-nowrap">
                                     <ItemTemplate>
                                         <asp:Literal ID="lName" runat="server" />
                                     </ItemTemplate>
@@ -137,7 +157,7 @@
                                         <asp:Literal ID="lCareTouches" runat="server"></asp:Literal>
                                     </ItemTemplate>
                                 </Rock:RockTemplateField>
-                                <Rock:RockTemplateField HeaderText="Assigned">
+                                <Rock:RockTemplateField HeaderText="Assigned" SortExpression="AssignedPersons" ItemStyle-CssClass="photo-icon-cell align-middle">
                                     <ItemTemplate>
                                         <asp:Literal ID="lAssigned" runat="server"></asp:Literal>
                                     </ItemTemplate>
@@ -191,6 +211,11 @@
                     });
                 }
                 Sys.Application.add_load(initDashboard);
+
+                function toggleNeeds(needId) {
+                    $('.hasParentNeed' + needId).toggleClass('hide');
+                    $('#toggleIcon' + needId).toggleClass('fa-plus').toggleClass('fa-minus');
+                }
             </script>
         </asp:Panel>
         <Rock:ModalDialog ID="mdMakeNote" runat="server" Title="Add Note" ValidationGroup="MakeNote" ClickBackdropToClose="true" Content-CssClass="modal-kfsmakenote">

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -25,15 +25,19 @@
     }
 
     .hasParentNeed {
-        background-color: #e6e6e6 !important;
+        background-color: #ececec !important;
     }
 
-    .table-striped > tbody > tr.assigned.hasParentNeed:nth-of-type(odd) {
+    .table-striped > tbody > tr.assigned.hasParentNeedAssigned:nth-of-type(odd) {
         background-color: oldlace !important;
     }
 
-    .table-striped > tbody > tr.assigned.hasParentNeed:nth-of-type(even) {
+    .table-striped > tbody > tr.assigned.hasParentNeedAssigned:nth-of-type(even) {
         background-color: #fff2da !important;
+    }
+
+    .assigned.hasParentNeed {
+        background-color: #feefd2 !important;
     }
 
     .grid-select-cell .photo-icon {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -813,7 +813,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                     var hasChildNeeds = false;
                     var hasParentNeed = false;
-                    if ( careNeed.ChildNeeds != null && ( ( careNeed.ChildNeeds.Any( cn => !cn.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) ) && _canViewAll ) || ( careNeed.ChildNeeds.Any( cn => cn.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) ) && !_canViewAll ) ) )
+                    if ( careNeed.ChildNeeds != null &&
+                            (
+                                ( careNeed.ChildNeeds.Any( cn => !cn.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) ) && _canViewAll ) ||
+                                ( careNeed.ChildNeeds.Any( cn => cn.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) ) && !_canViewAll )
+                            )
+                       )
                     {
                         hasChildNeeds = true;
                         e.Row.AddCssClass( "hasChildNeeds" );

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -1034,7 +1034,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             }
                             else
                             {
-                                parentNeedStr = string.Format( "<i class=\"fas fa-child mx-2\" data-toggle=\"tooltip\" title=\"Has a Parent Need: {0} - {1}\"></i></a>", careNeed.ParentNeed.Details.StripHtml().Truncate( 30 ), careNeed.ParentNeed.PersonAlias.Person.FullName );
+                                parentNeedStr = string.Format( "<i class=\"fas fa-child mx-2\" data-toggle=\"tooltip\" title=\"Has a Parent Need: {0} - {1}\"></i>", careNeed.ParentNeed.Details.StripHtml().Truncate( 30 ), careNeed.ParentNeed.PersonAlias.Person.FullName );
                             }
                         }
                         if ( careNeed.PersonAlias != null )
@@ -2123,6 +2123,11 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
         private IQueryable<CareNeed> PermissionFilterQuery( IQueryable<CareNeed> qry )
         {
+            if ( !_canViewCareWorker )
+            {
+                qry = qry.Where( cn => !cn.WorkersOnly );
+            }
+            
             if ( !_canViewAll )
             {
                 qry = qry.Where( cn => cn.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) && ( !cn.ParentNeedId.HasValue || ( cn.ParentNeedId.HasValue && !cn.ParentNeed.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) ) ) );

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -767,7 +767,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         }
 
         /// <summary>
-        /// Handles the RowDataBound event of the gGroupMembers control.
+        /// Handles the RowDataBound event of the gList control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="System.Web.UI.WebControls.GridViewRowEventArgs"/> instance containing the event data.</param>
@@ -823,9 +823,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     if ( careNeed.ParentNeedId.HasValue )
                     {
                         hasParentNeed = true;
-                        e.Row.AddCssClass( "hasParentNeed" );
                         if ( !e.Row.HasCssClass( "assigned" ) || careNeed.ParentNeed.AssignedPersons.Any( ap => ap.PersonAliasId == CurrentPersonAliasId ) )
                         {
+                            e.Row.AddCssClass( "hasParentNeed" );
                             e.Row.AddCssClass( "hide" );
                             e.Row.AddCssClass( string.Format( "hasParentNeed{0}", careNeed.ParentNeedId.Value ) );
 
@@ -840,6 +840,10 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                     rbfDetails.Visible = false;
                                 }
                             }
+                        }
+                        else
+                        {
+                            e.Row.AddCssClass( "hasParentNeedAssigned" );
                         }
                     }
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2035,7 +2035,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 string firstName = tbFollowUpFirstName.Text;
                 if ( !string.IsNullOrWhiteSpace( firstName ) )
                 {
-                    qry = qry.Where( b => b.PersonAlias.Person.FirstName.StartsWith( firstName ) );
+                    qry = qry.Where( b => b.PersonAlias.Person.FirstName.StartsWith( firstName ) || b.PersonAlias.Person.NickName.StartsWith( firstName ) );
                 }
 
                 // Filter by Last Name

--- a/StepsToCare/CareEntry.ascx
+++ b/StepsToCare/CareEntry.ascx
@@ -120,6 +120,7 @@
 
                 <asp:LinkButton ID="lbSave" runat="server" AccessKey="s" ToolTip="Alt+s" Text="Save" CssClass="btn btn-primary" OnClick="lbSave_Click" />
                 <asp:LinkButton ID="lbCancel" runat="server" AccessKey="c" ToolTip="Alt+c" Text="Cancel" CssClass="btn btn-link" CausesValidation="false" OnClick="lbCancel_Click" />
+                <Rock:RockCheckBox ID="cbIncludeFamily" runat="server" Text="Include Family" DisplayInline="true" FormGroupCssClass="d-inline-block" />
                 <Rock:RockCheckBox ID="cbWorkersOnly" runat="server" Text="Workers Only" DisplayInline="true" FormGroupCssClass="d-inline-block" />
             </div>
         </asp:Panel>

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using NuGet;
 using Rock;
 using Rock.Attribute;
 using Rock.Communication;
@@ -76,6 +77,26 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         DefaultBooleanValue = false,
         Key = AttributeKey.VerboseLogging )]
 
+    [CustomDropdownListField( "Load Balanced Workers assignment type",
+        Description = "How should the auto assign worker load balancing work? Prioritize, it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. Exclusive, if there are workers with matching campus, category or other parameters it will only load balance between those workers.",
+        ListSource = "Prioritize,Exclusive",
+        DefaultValue = "Prioritize",
+        Key = AttributeKey.LoadBalanceWorkersType )]
+
+    [BooleanField( "Enable Family Needs",
+        Description = "Show a checkbox to 'Include Family' which will create duplicate Care Needs for each family member with their own workers.",
+        DefaultBooleanValue = false,
+        Key = AttributeKey.EnableFamilyNeeds,
+        Category = AttributeCategory.FamilyNeeds )]
+
+    [CustomDropdownListField( "Adults in Family Workers",
+        Description = "How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).",
+        ListSource = "Normal,Workers Only",
+        DefaultValue = "Normal",
+        Key = AttributeKey.AdultFamilyWorkers,
+        Category = AttributeCategory.FamilyNeeds )]
+
+
     #endregion
 
     public partial class CareEntry : Rock.Web.UI.RockBlock
@@ -92,6 +113,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string AutoAssignWorker = "AutoAssignWorker";
             public const string NewAssignmentNotification = "NewAssignmentNotification";
             public const string VerboseLogging = "VerboseLogging";
+            public const string EnableFamilyNeeds = "EnableFamilyNeeds";
+            public const string AdultFamilyWorkers = "AdultFamilyWorkers";
+            public const string LoadBalanceWorkersType = "LoadBalanceWorkersType";
         }
         private static class PageParameterKey
         {
@@ -101,6 +125,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string CampusId = "CampusId";
             public const string Category = "Category";
             public const string Details = "Details";
+            public const string CareNeedId = "CareNeedId";
+        }
+
+        private static class AttributeCategory
+        {
+            public const string FamilyNeeds = "Family Needs";
         }
 
         private bool _allowNewPerson = false;
@@ -151,7 +181,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             gAssignedPersons.Actions.ShowAdd = false;
             gAssignedPersons.ShowActionRow = false;
 
-            _allowNewPerson = GetAttributeValue( "AllowNewPerson" ).AsBoolean();
+            _allowNewPerson = GetAttributeValue( AttributeKey.AllowNewPerson ).AsBoolean();
         }
 
         /// <summary>
@@ -165,7 +195,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             if ( !Page.IsPostBack )
             {
                 cpCampus.Campuses = CampusCache.All();
-                ShowDetail( PageParameter( "CareNeedId" ).AsInteger() );
+                ShowDetail( PageParameter( PageParameterKey.CareNeedId ).AsInteger() );
             }
             else
             {
@@ -195,7 +225,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void Block_BlockUpdated( object sender, EventArgs e )
         {
-            ShowDetail( PageParameter( "CareNeedId" ).AsInteger() );
+            ShowDetail( PageParameter( PageParameterKey.CareNeedId ).AsInteger() );
         }
 
         /// <summary>
@@ -212,7 +242,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 AssignedPersonService assignedPersonService = new AssignedPersonService( rockContext );
 
                 CareNeed careNeed = null;
-                int careNeedId = PageParameter( "CareNeedId" ).AsInteger();
+                int careNeedId = PageParameter( PageParameterKey.CareNeedId ).AsInteger();
                 var isNew = false;
 
                 if ( !careNeedId.Equals( 0 ) )
@@ -231,10 +261,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 careNeed.PersonAliasId = ppPerson.PersonAliasId;
 
+                Person person = null;
+
                 if ( _allowNewPerson && ppPerson.PersonId == null )
                 {
                     var personService = new PersonService( new RockContext() );
-                    var person = personService.FindPerson( new PersonService.PersonMatchQuery( dtbFirstName.Text, dtbLastName.Text, ebEmail.Text, pnbCellPhone.Number ), false, true, false );
+                    person = personService.FindPerson( new PersonService.PersonMatchQuery( dtbFirstName.Text, dtbLastName.Text, ebEmail.Text, pnbCellPhone.Number ), false, true, false );
 
                     if ( person == null && dtbFirstName.Text.IsNotNullOrWhiteSpace() && dtbLastName.Text.IsNotNullOrWhiteSpace() && ( !string.IsNullOrWhiteSpace( ebEmail.Text ) || !string.IsNullOrWhiteSpace( PhoneNumber.CleanNumber( pnbHomePhone.Number ) ) || !string.IsNullOrWhiteSpace( PhoneNumber.CleanNumber( pnbCellPhone.Number ) ) ) )
                     {
@@ -325,6 +357,10 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         return;
                     }
                 }
+                else if ( ppPerson.PersonId.HasValue )
+                {
+                    person = new PersonService( rockContext ).Get( ppPerson.PersonId.Value );
+                }
 
                 careNeed.SubmitterAliasId = ppSubmitter.PersonAliasId;
 
@@ -387,6 +423,24 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     careNeed.LoadAttributes();
                     Helper.GetEditValues( phAttributes, careNeed );
 
+                    if ( cbIncludeFamily.Visible && cbIncludeFamily.Checked && isNew )
+                    {
+                        var family = person.GetFamilyMembers( false, rockContext );
+                        foreach ( var fm in family )
+                        {
+                            var copyNeed = ( CareNeed ) careNeed.Clone();
+                            copyNeed.Id = 0;
+                            copyNeed.Guid = Guid.NewGuid();
+                            copyNeed.PersonAliasId = fm.Person.PrimaryAliasId;
+
+                            if ( careNeed.ChildNeeds == null )
+                            {
+                                careNeed.ChildNeeds = new List<CareNeed>();
+                            }
+                            careNeed.ChildNeeds.Add( copyNeed );
+                        }
+                    }
+
                     rockContext.WrapTransaction( () =>
                     {
                         rockContext.SaveChanges();
@@ -396,6 +450,24 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     if ( isNew )
                     {
                         AutoAssignWorkers( careNeed );
+                        if ( careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
+                        {
+                            var familyGroupType = GroupTypeCache.GetFamilyGroupType();
+                            var adultRoleId = familyGroupType.Roles.FirstOrDefault( a => a.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() ).Id;
+                            foreach ( var need in careNeed.ChildNeeds )
+                            {
+
+                                if ( need.PersonAlias != null && need.PersonAlias.Person.GetFamilyRole().Id != adultRoleId )
+                                {
+                                    AutoAssignWorkers( need, true, true );
+                                }
+                                else
+                                {
+                                    var adultFamilyWorkers = GetAttributeValue( AttributeKey.AdultFamilyWorkers );
+                                    AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only" );
+                                }
+                            }
+                        }
                     }
 
                     // if a NewAssignmentNotificationEmailTemplate is configured, send an email
@@ -411,7 +483,15 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         // Reload Care Need after save changes
                         careNeed = new CareNeedService( new RockContext() ).Get( careNeed.Id );
                         assignedPersons = careNeed.AssignedPersons;
+                        if ( careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
+                        {
+                            foreach ( var need in careNeed.ChildNeeds )
+                            {
+                                assignedPersons.AddRange( need.AssignedPersons );
+                            }
+                        }
                     }
+
                     if ( assignedPersons != null && assignedPersons.Any() && assignmentEmailTemplateGuid.HasValue && ( isNew || newlyAssignedPersons.Any() ) )
                     {
                         var errors = new List<string>();
@@ -740,6 +820,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 pdAuditDetails.Visible = false;
             }
 
+            cbIncludeFamily.Visible = GetAttributeValue( AttributeKey.EnableFamilyNeeds ).AsBoolean();
+
             pnlNewPersonFields.Visible = _allowNewPerson;
             ppPerson.Required = !_allowNewPerson;
 
@@ -747,6 +829,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             dpDate.SelectedDateTime = careNeed.DateEntered ?? PageParameter( PageParameterKey.DateEntered ).AsDateTime();
 
             cbWorkersOnly.Checked = careNeed.WorkersOnly;
+            cbIncludeFamily.Checked = careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any();
 
             var paramCampusId = PageParameter( PageParameterKey.CampusId ).AsIntegerOrNull();
             if ( careNeed.Campus != null )
@@ -878,12 +961,13 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             ppSubmitter.Visible = true;
         }
 
-        private void AutoAssignWorkers( CareNeed careNeed )
+        private void AutoAssignWorkers( CareNeed careNeed, bool roundRobinOnly = false, bool childAssignment = false )
         {
             var rockContext = new RockContext();
 
             var autoAssignWorker = GetAttributeValue( AttributeKey.AutoAssignWorker ).AsBoolean();
             var autoAssignWorkerGeofence = GetAttributeValue( AttributeKey.AutoAssignWorkerGeofence ).AsBoolean();
+            var loadBalanceType = GetAttributeValue( AttributeKey.LoadBalanceWorkersType );
 
             var careNeedService = new CareNeedService( rockContext );
             var careWorkerService = new CareWorkerService( rockContext );
@@ -899,7 +983,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             var enableLogging = GetAttributeValue( AttributeKey.VerboseLogging ).AsBoolean();
 
             // auto assign Deacon/Worker by Geofence
-            if ( autoAssignWorkerGeofence )
+            if ( autoAssignWorkerGeofence && !roundRobinOnly )
             {
                 if ( enableLogging )
                 {
@@ -960,13 +1044,14 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 var closedId = DefinedValueCache.Get( rocks.kfs.StepsToCare.SystemGuid.DefinedValue.CARE_NEED_STATUS_CLOSED ).Id;
                 var careWorkerCount1 = careWorkersNoFence
                     .Where( cw => cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) && cw.Campuses.Contains( careNeed.CampusId.ToString() ) )
-                    .Select( cw => new
+                    .Select( cw => new WorkerResult
                     {
                         Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
                         Worker = cw,
-                        HasCategoryAndCampus = true,
-                        HasCategory = false,
-                        HasCampus = false
+                        HasCategory = true,
+                        HasCampus = true,
+                        HasAgeRange = false,
+                        HasGender = false
                     }
                     )
                     .OrderBy( cw => cw.Count )
@@ -980,13 +1065,14 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var careWorkerCount2 = careWorkersNoFence
                     .Where( cw => cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) && !cw.Campuses.Contains( careNeed.CampusId.ToString() ) )
-                    .Select( cw => new
+                    .Select( cw => new WorkerResult
                     {
                         Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
                         Worker = cw,
-                        HasCategoryAndCampus = false,
                         HasCategory = true,
-                        HasCampus = false
+                        HasCampus = false,
+                        HasAgeRange = false,
+                        HasGender = false
                     }
                     )
                     .OrderBy( cw => cw.Count )
@@ -1001,13 +1087,14 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var careWorkerCount3 = careWorkersNoFence
                     .Where( cw => !cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) && cw.Campuses.Contains( careNeed.CampusId.ToString() ) )
-                    .Select( cw => new
+                    .Select( cw => new WorkerResult
                     {
                         Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
                         Worker = cw,
-                        HasCategoryAndCampus = false,
                         HasCategory = false,
-                        HasCampus = true
+                        HasCampus = true,
+                        HasAgeRange = false,
+                        HasGender = false
                     }
                     )
                     .OrderBy( cw => cw.Count )
@@ -1019,15 +1106,17 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount3 Count: {1}", careNeed.Guid, careWorkerCount3.Count() ), "careWorkerCount3, Campus NOT Category" );
                 }
 
+                // None, doesn't include parameters for other values though.
                 var careWorkerCount4 = careWorkersNoFence
                     .Where( cw => !cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) && !cw.Campuses.Contains( careNeed.CampusId.ToString() ) )
-                    .Select( cw => new
+                    .Select( cw => new WorkerResult
                     {
                         Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
                         Worker = cw,
-                        HasCategoryAndCampus = false,
                         HasCategory = false,
-                        HasCampus = false
+                        HasCampus = false,
+                        HasAgeRange = false,
+                        HasGender = false
                     }
                     )
                     .OrderBy( cw => cw.Count )
@@ -1039,14 +1128,214 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount4 Count: {1}", careNeed.Guid, careWorkerCount4.Count() ), "careWorkerCount4, NOT Campus or Category" );
                 }
 
-                var careWorkerCounts = careWorkerCount1
-                    .Concat( careWorkerCount2 )
-                    .Concat( careWorkerCount3 )
-                    .Concat( careWorkerCount4 )
-                    .OrderBy( ct => ct.Count )
-                    .ThenByDescending( ct => ct.HasCategoryAndCampus )
-                    .ThenByDescending( ct => ct.HasCategory )
-                    .ThenByDescending( ct => ct.HasCampus );
+                IOrderedQueryable<WorkerResult> careWorkersCountChild1 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild2 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild3 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild4 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild5 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild6 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild7 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild8 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild9 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild10 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild11 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild12 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild13 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild14 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild15 = null;
+                IOrderedQueryable<WorkerResult> careWorkersCountChild16 = null;
+                if ( childAssignment )
+                {
+                    // AgeRange, Gender, Campus, Category
+                    careWorkersCountChild1 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, true );
+
+                    // AgeRange, Gender, Category
+                    careWorkersCountChild2 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, true );
+
+                    // AgeRange, Gender, Campus
+                    careWorkersCountChild3 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, false );
+
+                    // AgeRange, Campus, Category
+                    careWorkersCountChild4 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, true );
+
+                    // Gender, Campus, Category
+                    careWorkersCountChild5 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, true );
+
+                    // AgeRange, Gender
+                    careWorkersCountChild6 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, false );
+
+                    // AgeRange, Category
+                    careWorkersCountChild7 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, true );
+
+                    // AgeRange, Campus
+                    careWorkersCountChild8 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, false );
+
+                    // Gender, Category
+                    careWorkersCountChild9 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, true );
+
+                    // Gender, Campus
+                    careWorkersCountChild10 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, false );
+
+                    // Campus, Category
+                    careWorkersCountChild11 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, true );
+
+                    // AgeRange
+                    careWorkersCountChild12 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, false );
+
+                    // Gender 
+                    careWorkersCountChild13 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, false );
+
+                    // Category
+                    careWorkersCountChild14 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, true );
+
+                    // Campus
+                    careWorkersCountChild15 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, false );
+
+                    // None
+                    careWorkersCountChild16 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, false );
+
+                }
+
+                var careWorkerCounts = careWorkerCount1;
+                if ( loadBalanceType == "Prioritize" )
+                {
+                    if ( childAssignment )
+                    {
+                        careWorkerCounts = careWorkersCountChild1
+                                            .Concat( careWorkersCountChild2 )
+                                            .Concat( careWorkersCountChild3 )
+                                            .Concat( careWorkersCountChild4 )
+                                            .Concat( careWorkersCountChild5 )
+                                            .Concat( careWorkersCountChild6 )
+                                            .Concat( careWorkersCountChild7 )
+                                            .Concat( careWorkersCountChild8 )
+                                            .Concat( careWorkersCountChild9 )
+                                            .Concat( careWorkersCountChild10 )
+                                            .Concat( careWorkersCountChild11 )
+                                            .Concat( careWorkersCountChild12 )
+                                            .Concat( careWorkersCountChild13 )
+                                            .Concat( careWorkersCountChild14 )
+                                            .Concat( careWorkersCountChild15 )
+                                            .Concat( careWorkersCountChild16 )
+                                            .OrderBy( ct => ct.Count )
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )         // AgeRange, Gender, Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )        // AgeRange, Gender, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )        // AgeRange, Gender, Campus
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )        // AgeRange, Campus, Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )        // Gender, Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )       // AgeRange, Gender
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )       // AgeRange, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )       // AgeRange, Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )       // Gender, Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )       // Gender, Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )       // Campus, Category
+                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // AgeRange
+                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // Gender
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )      // Category
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )      // Campus
+                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory );    // None
+                    }
+                    else
+                    {
+                        careWorkerCounts = careWorkerCount1
+                                        .Concat( careWorkerCount2 )
+                                        .Concat( careWorkerCount3 )
+                                        .Concat( careWorkerCount4 )
+                                        .OrderBy( ct => ct.Count )
+                                        .ThenByDescending( ct => ct.HasCategory && ct.HasCampus )
+                                        .ThenByDescending( ct => ct.HasCategory && !ct.HasCampus )
+                                        .ThenByDescending( ct => ct.HasCampus && !ct.HasCategory );
+                    }
+                }
+                else
+                {
+                    if ( childAssignment )
+                    {
+                        if ( careWorkersCountChild1.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild1;
+                        }
+                        else if ( careWorkersCountChild2.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild2;
+                        }
+                        else if ( careWorkersCountChild3.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild3;
+                        }
+                        else if ( careWorkersCountChild4.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild4;
+                        }
+                        else if ( careWorkersCountChild5.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild5;
+                        }
+                        else if ( careWorkersCountChild6.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild6;
+                        }
+                        else if ( careWorkersCountChild7.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild7;
+                        }
+                        else if ( careWorkersCountChild8.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild8;
+                        }
+                        else if ( careWorkersCountChild9.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild9;
+                        }
+                        else if ( careWorkersCountChild10.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild10;
+                        }
+                        else if ( careWorkersCountChild11.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild11;
+                        }
+                        else if ( careWorkersCountChild12.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild12;
+                        }
+                        else if ( careWorkersCountChild13.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild13;
+                        }
+                        else if ( careWorkersCountChild14.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild14;
+                        }
+                        else if ( careWorkersCountChild15.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild15;
+                        }
+                        else if ( careWorkersCountChild16.Any() )
+                        {
+                            careWorkerCounts = careWorkersCountChild16;
+                        }
+                    }
+                    else
+                    {
+                        if ( careWorkerCount1.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount1;
+                        }
+                        else if ( careWorkerCount2.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount2;
+                        }
+                        else if ( careWorkerCount3.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount3;
+                        }
+                        else if ( careWorkerCount4.Any() )
+                        {
+                            careWorkerCounts = careWorkerCount4;
+                        }
+                    }
+                }
 
                 if ( enableLogging )
                 {
@@ -1085,7 +1374,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, Leader Role Guid: {1}, Leader Role: {2}", careNeed.Guid, leaderRoleGuid, leaderRole.Id ), "Get Leader Role" );
             }
 
-            if ( leaderRole != null )
+            if ( leaderRole != null && !roundRobinOnly )
             {
                 var groupMemberService = new GroupMemberService( rockContext );
                 var inGroups = groupMemberService.GetByPersonId( careNeed.PersonAlias.PersonId ).Where( gm => gm.Group != null && gm.Group.IsActive && !gm.Group.IsArchived && gm.Group.GroupTypeId == leaderRole.GroupTypeId && !gm.IsArchived && gm.GroupMemberStatus == GroupMemberStatus.Active ).Select( gm => gm.GroupId );
@@ -1117,6 +1406,72 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 }
             }
             rockContext.SaveChanges();
+        }
+
+        private static IOrderedQueryable<WorkerResult> GenerateAgeQuery( CareNeed careNeed, IQueryable<CareWorker> careWorkersNoFence, int closedId, bool includeAgeRange, bool includeGender, bool includeCampus, bool includeCategory )
+        {
+            var ageAsDecimal = ( decimal ) careNeed.PersonAlias.Person.AgePrecise;
+            var tempQuery = careWorkersNoFence;
+
+            if ( includeAgeRange )
+            {
+                tempQuery = tempQuery.Where( cw => (
+                                                    ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
+                                                    ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
+                                                    ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
+                                                   )
+                                            );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => !(
+                                                     ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
+                                                     ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
+                                                     ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
+                                                    )
+                                            );
+            }
+
+            if ( includeGender )
+            {
+                tempQuery = tempQuery.Where( cw => cw.Gender == careNeed.PersonAlias.Person.Gender );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => cw.Gender != careNeed.PersonAlias.Person.Gender );
+            }
+
+            if ( includeCategory )
+            {
+                tempQuery = tempQuery.Where( cw => cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => !cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
+            }
+
+            if ( includeCampus )
+            {
+                tempQuery = tempQuery.Where( cw => cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
+            }
+            else
+            {
+                tempQuery = tempQuery.Where( cw => !cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
+            }
+
+            return tempQuery.Select( cw => new WorkerResult
+                                        {
+                                            Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
+                                            Worker = cw,
+                                            HasCategory = includeCategory,
+                                            HasCampus = includeCampus,
+                                            HasAgeRange = includeAgeRange,
+                                            HasGender = includeGender
+                                        }
+                                    )
+                                    .OrderBy( cw => cw.Count )
+                                    .ThenBy( cw => cw.Worker.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) )
+                                    .ThenBy( cw => cw.Worker.Campuses.Contains( careNeed.CampusId.ToString() ) );
         }
 
         /// <summary>
@@ -1181,5 +1536,15 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
 
         #endregion
+    }
+
+    public partial class WorkerResult
+    {
+        public int Count { get; set; }
+        public CareWorker Worker { get; set; }
+        public bool HasCategory { get; set; } = false;
+        public bool HasCampus { get; set; } = false;
+        public bool HasAgeRange { get; set; } = false;
+        public bool HasGender { get; set; } = false;
     }
 }

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -78,9 +78,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.VerboseLogging )]
 
     [CustomDropdownListField( "Load Balanced Workers assignment type",
-        Description = "How should the auto assign worker load balancing work? Prioritize, it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. Exclusive, if there are workers with matching campus, category or other parameters it will only load balance between those workers.",
+        Description = "How should the auto assign worker load balancing work? Default: Exclusive. \"Prioritize\", it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. \"Exclusive\", if there are workers with matching campus, category or other parameters it will only load balance between those workers.",
         ListSource = "Prioritize,Exclusive",
-        DefaultValue = "Prioritize",
+        DefaultValue = "Exclusive",
         Key = AttributeKey.LoadBalanceWorkersType )]
 
     [BooleanField( "Enable Family Needs",
@@ -90,7 +90,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Category = AttributeCategory.FamilyNeeds )]
 
     [CustomDropdownListField( "Adults in Family Worker Assignment",
-        Description = "How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).",
+        Description = "How should workers be assigned to spouses and other adults in the family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).",
         ListSource = "Normal,Workers Only",
         DefaultValue = "Normal",
         Key = AttributeKey.AdultFamilyWorkers,
@@ -476,7 +476,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         var adultRoleId = familyGroupType.Roles.FirstOrDefault( a => a.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() ).Id;
                         foreach ( var need in careNeed.ChildNeeds )
                         {
-
                             if ( need.PersonAlias != null && need.PersonAlias.Person.GetFamilyRole().Id != adultRoleId )
                             {
                                 AutoAssignWorkers( need, true, true );

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -89,7 +89,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.EnableFamilyNeeds,
         Category = AttributeCategory.FamilyNeeds )]
 
-    [CustomDropdownListField( "Adults in Family Workers",
+    [CustomDropdownListField( "Adults in Family Worker Assignment",
         Description = "How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).",
         ListSource = "Normal,Workers Only",
         DefaultValue = "Normal",

--- a/StepsToCare/CareWorkers.ascx
+++ b/StepsToCare/CareWorkers.ascx
@@ -29,6 +29,9 @@
                             <Rock:PersonField DataField="PersonAlias.Person" SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName, LastName, FirstName" HeaderText="Name"></Rock:PersonField>
                             <Rock:DefinedValueField DataField="CategoryValues" HeaderText="Category"></Rock:DefinedValueField>
                             <Rock:CampusField DataField="Campuses" HeaderText="Campus" SortExpression="Campuses" />
+                            <Rock:RockBoundField DataField="AgeRangeMin" HeaderText="Age Min"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="AgeRangeMax" HeaderText="Age Max"></Rock:RockBoundField>
+                            <Rock:RockBoundField DataField="Gender" HeaderText="Gender"></Rock:RockBoundField>
                             <Rock:RockBoundField DataField="GeoFenceId" HeaderText="Geofence"></Rock:RockBoundField>
                             <Rock:BoolField DataField="IsActive" HeaderText="Active"></Rock:BoolField>
                         </Columns>

--- a/StepsToCare/CareWorkers.ascx
+++ b/StepsToCare/CareWorkers.ascx
@@ -59,9 +59,22 @@
 
                 <div class="row">
                     <div class="col-md-4">
-                        <Rock:LocationPicker ID="lpGeofenceLocation" runat="server" Label="Geofence Location" AllowedPickerModes="Named" Help="If geofence is set it is used for auto assignment of care needs based on where the person's home is located. Only named Polygon/Geofence locations are supported to minimize where you can create the area for use in multiple entities such as Groups."/>
+                        <Rock:LocationPicker ID="lpGeofenceLocation" runat="server" Label="Geofence Location" AllowedPickerModes="Named" Help="If geofence is set it is used for auto assignment of care needs based on where the person's home is located. Only named Polygon/Geofence locations are supported to minimize where you can create the area for use in multiple entities such as Groups." />
                     </div>
-                    <div class="col-md-2">
+                    <div class="col-md-4">
+                        <Rock:NumberRangeEditor ID="nreAgeRange" runat="server" Label="Age Range" Help="If using 'Include Family' checkbox on Care Entry it will take into account age ranges for family members" />
+                    </div>
+                    <div class="col-md-4">
+                        <Rock:RockDropDownList ID="ddlGender" runat="server" Label="Gender" Help="If using 'Include Family' checkbox on Care Entry it will take into account Gender for family members.">
+                            <asp:ListItem Text="" Value="" />
+                            <asp:ListItem Text="Male" Value="Male" />
+                            <asp:ListItem Text="Female" Value="Female" />
+                            <asp:ListItem Text="Unknown" Value="Unknown" />
+                        </Rock:RockDropDownList>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-4">
                         <Rock:RockCheckBox ID="cbActive" runat="server" Label="Active" />
                     </div>
                 </div>

--- a/StepsToCare/CareWorkers.ascx
+++ b/StepsToCare/CareWorkers.ascx
@@ -62,10 +62,10 @@
                         <Rock:LocationPicker ID="lpGeofenceLocation" runat="server" Label="Geofence Location" AllowedPickerModes="Named" Help="If geofence is set it is used for auto assignment of care needs based on where the person's home is located. Only named Polygon/Geofence locations are supported to minimize where you can create the area for use in multiple entities such as Groups." />
                     </div>
                     <div class="col-md-4">
-                        <Rock:NumberRangeEditor ID="nreAgeRange" runat="server" Label="Age Range" Help="If using 'Include Family' checkbox on Care Entry it will take into account age ranges for family members" />
+                        <Rock:NumberRangeEditor ID="nreAgeRange" runat="server" Label="Age Range" Help="If using 'Include Family' checkbox on Care Entry it will take into account age ranges for appropriate family members" />
                     </div>
                     <div class="col-md-4">
-                        <Rock:RockDropDownList ID="ddlGender" runat="server" Label="Gender" Help="If using 'Include Family' checkbox on Care Entry it will take into account Gender for family members.">
+                        <Rock:RockDropDownList ID="ddlGender" runat="server" Label="Gender" Help="If using 'Include Family' checkbox on Care Entry it will take into account Gender for appropriate family members.">
                             <asp:ListItem Text="" Value="" />
                             <asp:ListItem Text="Male" Value="Male" />
                             <asp:ListItem Text="Female" Value="Female" />

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -242,7 +242,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     int? workerId = PageParameter( "CareWorkerId" ).AsIntegerOrNull();
                     var personCampus = person.GetCampus();
 
-                    if ( !cpCampus.SelectedCampusIds.Contains( personCampus.Id ) && ( e != null || ( workerId.HasValue && workerId == 0 ) ) )
+                    if ( personCampus != null && !cpCampus.SelectedCampusIds.Contains( personCampus.Id ) && ( e != null || ( workerId.HasValue && workerId == 0 ) ) )
                     {
                         cpCampus.SelectedValue = personCampus?.Id.ToString();
                     }
@@ -524,12 +524,39 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             if ( careWorker.GeoFenceId != null )
             {
                 var location = new LocationService( rockContext ).Get( careWorker.GeoFenceId.Value );
-                lpGeofenceLocation.SetBestPickerModeForLocation( location );
+                //lpGeofenceLocation.SetBestPickerModeForLocation( location );
                 lpGeofenceLocation.Location = location;
             }
             else
             {
                 lpGeofenceLocation.Location = null;
+            }
+
+            if ( careWorker.AgeRangeMax.HasValue )
+            {
+                nreAgeRange.UpperValue = careWorker.AgeRangeMax.Value;
+            }
+            else
+            {
+                nreAgeRange.UpperValue = null;
+            }
+
+            if ( careWorker.AgeRangeMin.HasValue )
+            {
+                nreAgeRange.LowerValue = careWorker.AgeRangeMin.Value;
+            }
+            else
+            {
+                nreAgeRange.LowerValue = null;
+            }
+
+            if ( careWorker.Gender.HasValue )
+            {
+                ddlGender.SetValue( careWorker.Gender.Value.ToString() );
+            }
+            else
+            {
+                ddlGender.ClearSelection();
             }
 
             careWorker.LoadAttributes();
@@ -571,6 +598,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 careWorker.IsActive = cbActive.Checked;
 
                 careWorker.GeoFenceId = lpGeofenceLocation.Location?.Id;
+
+                careWorker.AgeRangeMin = nreAgeRange.LowerValue;
+
+                careWorker.AgeRangeMax = nreAgeRange.UpperValue;
+
+                careWorker.Gender = ddlGender.SelectedValueAsEnumOrNull<Gender>();
 
                 if ( careWorker.IsValid )
                 {

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -524,7 +524,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             if ( careWorker.GeoFenceId != null )
             {
                 var location = new LocationService( rockContext ).Get( careWorker.GeoFenceId.Value );
-                //lpGeofenceLocation.SetBestPickerModeForLocation( location );
                 lpGeofenceLocation.Location = location;
             }
             else


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added capability to "Include Family" on care needs. Which will then create individual care needs for each family member and be assigned appropriately. With this new capability it will then display them on the dashboard underneath a + icon in a fashion similar to an accordion. If a Care worker is assigned to the parent and child need they will both show up at the top of the list in the default sort order. If a worker is only assigned to a "child" need and not the parent they will see the need in their assigned list outside of the accordion/collapsed view.

**New Settings:**

Care Entry:   
_Load Balanced Workers assignment type_, How should the auto assign worker load balancing work? Prioritize, it will prioritize the workers being assigned based on campus, category and any other parameters on the worker but still assign to any worker if their workload matches. Exclusive, if there are workers with matching campus, category or other parameters it will only load balance between those workers.
_Adults in Family Worker Assignment_, How should workers be assigned to other adults in family when using 'Family Needs'. Normal behavior, use the same settings as a normal Care Need (Group Leader, Geofence and load balanced), or assign to Care Workers Only (load balanced).
_Enable Family Needs_, Show a checkbox to 'Include Family' which will create duplicate Care Needs for each family member with their own workers.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added capability to "Include Family" on care needs. Which will then create individual care needs for each family member and be assigned appropriately.
- Added additional criteria for Care Workers specific to non-adult family members being assigned workers. (Age Range and Gender)
- Introduced a new setting to be able to use the criteria to prioritize OR make it exclusive to only assign workers with matching criteria (Campus and Category for all needs, Campus, Category, Age Range and Gender for family needs)

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

Include family checkbox:   
![image](https://user-images.githubusercontent.com/2990519/157756049-9f7cd119-aed1-4134-bcab-63e70139bafe.png)

Collapsed, view all view, with some assigned and some not:   
![image](https://user-images.githubusercontent.com/2990519/157755956-bfee0837-5719-4720-a66b-3533b9264287.png)

Expanded, view all view:   
![image](https://user-images.githubusercontent.com/2990519/157755768-01784a47-e80d-404a-99e6-01d949e6501d.png)

Collapsed, assigned view:   
![image](https://user-images.githubusercontent.com/2990519/157755125-cc0975e9-3f30-430f-bc9d-e635515843f8.png)

Expanded, assigned view: (also shows if a child need has a different description/detail field)   
<img width="1193" alt="Screenshot 2022-03-10 140836" src="https://user-images.githubusercontent.com/2990519/157755344-4105d13d-fe82-4e62-ac08-6c079dd2c0da.png">

New settings on Care Entry Block:   
![image](https://user-images.githubusercontent.com/2990519/157756149-37bb7e91-ff2a-4d5d-b94e-06bda9d48bc5.png)

![image](https://user-images.githubusercontent.com/2990519/157756198-7172d45f-1fb4-4f24-aec5-469672b986c5.png)

Care Workers Changes:   
![localhost_6229_page_16285 (1)](https://user-images.githubusercontent.com/2990519/158465673-3eb9e329-e5a0-462a-b11c-ab98605190da.png)

![localhost_6229_page_16285 (2)](https://user-images.githubusercontent.com/2990519/158465679-764ca861-1342-4eaa-91cc-10a7ad7b14f9.png)

![image](https://user-images.githubusercontent.com/2990519/158463288-633ecc23-3605-4936-b426-6fcbbf352e69.png)

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs
- StepsToCare/CareEntry.ascx
- StepsToCare/CareEntry.ascx.cs
- StepsToCare/CareWorkers.ascx
- StepsToCare/CareWorkers.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Requires new DLL v1.3 or higher to run. https://github.com/KingdomFirst/RockAssemblies/pull/62
