### PR TITLE
Steps to Care - Null Birthdate check

### DIFF
--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -1375,12 +1375,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
         private static IOrderedQueryable<WorkerResult> GenerateAgeQuery( CareNeed careNeed, IQueryable<CareWorker> careWorkersNoFence, int closedId, bool includeAgeRange, bool includeGender, bool includeCampus, bool includeCategory, bool ignoreAgeRangeAndGender = false )
         {
-            var ageAsDecimal = ( decimal ) careNeed.PersonAlias.Person.AgePrecise;
+            var ageAsDecimal = ( decimal? ) careNeed.PersonAlias.Person.AgePrecise;
             var tempQuery = careWorkersNoFence;
 
             if ( includeAgeRange )
             {
-                tempQuery = tempQuery.Where( cw => (
+                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && (
                                                     ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
                                                     ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
                                                     ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
@@ -1389,7 +1389,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             }
             else if ( !ignoreAgeRangeAndGender )
             {
-                tempQuery = tempQuery.Where( cw => !(
+                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && !(
                                                      ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
                                                      ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
                                                      ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add null check for age, in case the person doesn't have a birthdate, quite common scenario I missed.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Add null check for Age Precise which is being used in the round robin assignment

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

StepsToCare/CareEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
