### PR TITLE
Steps to Care TargetPerson Mode

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -57,13 +57,14 @@
                 <div class="panel-heading">
                     <h1 class="panel-title"><i class="fa fa-hand-holding-heart mr-2"></i>Care Needs</h1>
                     <div class="pull-right d-flex align-items-center">
+                        <asp:Literal ID="lCategoriesHeader" runat="server" />
                         <asp:LinkButton ID="lbNotificationType" runat="server" CssClass="btn btn-xs btn-square btn-default pull-right" OnClick="lbNotificationType_Click" CausesValidation="false"> <i title="Choose Notification Type" class="fas fa-comment-alt"></i></asp:LinkButton>
                         <asp:LinkButton ID="lbCareConfigure" runat="server" CssClass="btn btn-xs btn-square btn-default pull-right" OnClick="lbCareConfigure_Click" CausesValidation="false"> <i title="Options" class="fa fa-gear"></i></asp:LinkButton>
                     </div>
                 </div>
                 <div class="panel-body">
 
-                    <div class="list-as-blocks clearfix margin-b-lg">
+                    <asp:Panel ID="pnlStepsToCareStats" runat="server" CssClass="list-as-blocks clearfix margin-b-lg">
                         <ul>
                             <li class="block-status care-count-touches">
                                 <a href="#" class="bg-teal-400 text-white text-uppercase">
@@ -93,10 +94,10 @@
                                 <asp:Literal ID="lCategories" runat="server" />
                             </li>
                         </ul>
-                    </div>
+                    </asp:Panel>
 
-                    <div class="grid grid-panel">
-                        <h5 class="pl-2">Care Dashboard</h5>
+                    <asp:Panel ID="pnlGrid" runat="server" CssClass="grid grid-panel">
+                        <h5 class="pl-2" id="hDashboard" runat="server">Care Dashboard</h5>
                         <Rock:GridFilter ID="rFilter" runat="server" OnDisplayFilterValue="rFilter_DisplayFilterValue" OnClearFilterClick="rFilter_ClearFilterClick">
                             <Rock:DateRangePicker ID="drpDate" runat="server" Label="Date Range" />
                             <Rock:RockTextBox ID="tbFirstName" runat="server" Label="First Name" />
@@ -132,8 +133,8 @@
                                 <%-- Columns are dynamically added due to dynamic content --%>
                             </Columns>
                         </Rock:Grid>
-                    </div>
-                    <div class="grid grid-panel">
+                    </asp:Panel>
+                    <asp:Panel ID="pnlFollowUpGrid" runat="server" CssClass="grid grid-panel">
                         <h5 class="pl-2">Care Follow Up</h5>
                         <Rock:GridFilter ID="rFollowUpFilter" runat="server" OnDisplayFilterValue="rFollowUpFilter_DisplayFilterValue" OnApplyFilterClick="rFollowUpFilter_ApplyFilterClick" OnClearFilterClick="rFollowUpFilter_ClearFilterClick">
                             <Rock:DateRangePicker ID="drpFollowUpDate" runat="server" Label="Date Range" />
@@ -169,7 +170,7 @@
                                 <%-- Columns are dynamically added due to dynamic content --%>
                             </Columns>
                         </Rock:Grid>
-                    </div>
+                    </asp:Panel>
                 </div>
             </div>
             <script type="text/javascript">

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -8,6 +8,8 @@
         display: inline;
     }
 
+    .grid-table>tbody>tr>td:empty, .grid-table>tbody>tr>th:empty, .grid-table>thead>tr>td:empty, .grid-table>thead>tr>th:empty { padding: 0; }
+
     .table-striped > tbody > tr.assigned:nth-of-type(odd) {
         background-color: oldlace;
     }

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -210,6 +210,10 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         SecurityActionKey.ViewAll,
         "The roles and/or users that have access to view all care needs minus 'Care Worker Only' those are protected by 'Care Workers'." )]
 
+    [SecurityAction(
+        SecurityActionKey.CompleteNeeds,
+        "The roles and/or users that have access to Complete Needs." )]
+
     #endregion Block Settings
 
     public partial class CareDashboard : Rock.Web.UI.RockBlock
@@ -275,6 +279,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         {
             public const string ViewAll = "ViewAll";
             public const string CareWorkers = "CareWorkers";
+            public const string CompleteNeeds = "CompleteNeeds";
         }
 
         /// <summary>
@@ -931,7 +936,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         var actionItem1 = new HtmlGenericControl( "li" );
                         ddlMenu.Controls.Add( actionItem1 );
 
-                        if ( _canEdit )
+                        var canCompleteNeeds = IsUserAuthorized( SecurityActionKey.CompleteNeeds );
+                        if ( canCompleteNeeds )
                         {
                             var lbCompleteNeed = new LinkButton();
                             lbCompleteNeed.Command += lbNeedAction_Click;

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -101,7 +101,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
     [BooleanField(
         "Target Person Mode Include Family Members",
-        Description = "When running in Target Person mode/a Person Detail tab, should we include family member needs in the list? Default: false.",
+        Description = "When running in Target Person mode (Page has Person specific content), should we include family member needs in the list? Default: false.",
         IsRequired = false,
         DefaultBooleanValue = false,
         Order = 7,

--- a/StepsToCare/CareEntry.ascx
+++ b/StepsToCare/CareEntry.ascx
@@ -1,5 +1,5 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="CareEntry.ascx.cs" Inherits="RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry" %>
-
+<style type="text/css">fieldset[id*='pwDetails'] .col-md-6:nth-child(odd) { clear: left; }</style>
 <asp:UpdatePanel runat="server" ID="upnlCareEntry">
     <ContentTemplate>
         <asp:Panel ID="pnlView" runat="server" CssClass="panel panel-block">

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ using Rock.Communication;
 using Rock.Data;
 using Rock.Logging;
 using Rock.Model;
+using Rock.Security;
 using Rock.Web;
 using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
@@ -96,7 +97,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.AdultFamilyWorkers,
         Category = AttributeCategory.FamilyNeeds )]
 
-
+    [SecurityAction(
+        SecurityActionKey.UpdateStatus,
+        "The roles and/or users that have access to update the status of Care Needs." )]
     #endregion
 
     public partial class CareEntry : Rock.Web.UI.RockBlock
@@ -131,6 +134,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         private static class AttributeCategory
         {
             public const string FamilyNeeds = "Family Needs";
+        }
+
+        private static class SecurityActionKey
+        {
+            public const string UpdateStatus = "UpdateStatus";
+
         }
 
         private bool _allowNewPerson = false;
@@ -904,6 +913,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             else
             {
                 dvpStatus.SelectedDefinedValueId = DefinedValueCache.Get( rocks.kfs.StepsToCare.SystemGuid.DefinedValue.CARE_NEED_STATUS_OPEN.AsGuid() ).Id;
+            }
+
+            var canUpdateStatus = IsUserAuthorized( SecurityActionKey.UpdateStatus );
+            if ( !canUpdateStatus )
+            {
+                dvpStatus.Visible = false;
             }
 
             var paramCategory = PageParameter( PageParameterKey.Category ).AsIntegerOrNull();


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Ensure TargetPerson mode works properly and make some special considerations for such.
- Add new "Care Needs" page to Person Detail/Profile pages in Rock.
- Added new "CompleteNeeds" and "UpdateStatus" security permissions.

**New Settings:**

- **Complete Needs**, The roles and/or users that have access to Complete Needs.
- **Target Person Mode Include Family Members**, When running in Target Person mode/a Person Detail tab, should we include family member needs in the list? Default: false.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Ensure TargetPerson mode works properly and make some special considerations for such.
- Add new "Care Needs" page to Person Detail/Profile pages in Rock.
- Added new "CompleteNeeds" and "UpdateStatus" security permissions.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

<img width="909" alt="image" src="https://user-images.githubusercontent.com/2990519/166479537-737dc1bc-d104-4e74-b533-60cc9178472b.png">

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs
- StepsToCare/CareEntry.ascx
- StepsToCare/CareEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, but there is a migration to set this new stuff up: https://github.com/KingdomFirst/RockAssemblies/pull/73
