### PR TITLE
Group Finder Bug Fix

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -221,7 +221,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
         Key = AttributeKey.HideFiltersInitialLoad )]
     [CustomCheckboxListField( "Exclude Attribute Values from Filter",
         Description = "Use this setting to hide attribute values from the available options in the search filter",
-        ListSource = "SELECT a.Name as Text, a.Id as Value FROM [Attribute] a JOIN [EntityType] et ON et.Id = a.EntityTypeId WHERE et.[Guid] = '9BBFDA11-0D22-40D5-902F-60ADFBC88987'",
+        ListSource = "SELECT a.Name as Text, CONCAT(a.[Key],'_',a.FieldTypeId) as Value FROM [Attribute] a JOIN [EntityType] et ON et.Id = a.EntityTypeId WHERE et.[Guid] = '9BBFDA11-0D22-40D5-902F-60ADFBC88987'",
         IsRequired = false, Category = AttributeCategory.CustomSetting,
         Key = AttributeKey.HideAttributeValues )]
 
@@ -1145,14 +1145,14 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                                     var definedType = DefinedTypeCache.Get( definedTypeId.Value );
                                     foreach ( var val in definedType.DefinedValues )
                                     {
-                                        cblAttributeHiddenOptions.Items.Add( new ListItem( ( useDescription ) ? val.Description : val.Value, string.Format( "filter_{0}||{1}", attribute.Value.Id.ToString(), val.Id.ToString() ) ) );
+                                        cblAttributeHiddenOptions.Items.Add( new ListItem( ( useDescription ) ? val.Description : val.Value, string.Format( "filter_{0}_{1}||{2}", attribute.Value.Key.ToString(), attribute.Value.FieldTypeId, val.Id.ToString() ) ) );
                                     }
                                 }
                                 else
                                 {
                                     foreach ( var keyVal in Rock.Field.Helper.GetConfiguredValues( configurationValues ) )
                                     {
-                                        cblAttributeHiddenOptions.Items.Add( new ListItem( keyVal.Value, string.Format( "filter_{0}||{1}", attribute.Value.Id.ToString(), keyVal.Key ) ) );
+                                        cblAttributeHiddenOptions.Items.Add( new ListItem( keyVal.Value, string.Format( "filter_{0}_{1}||{2}", attribute.Value.Key.ToString(), attribute.Value.FieldTypeId, keyVal.Key ) ) );
                                     }
                                 }
                             }

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -660,8 +660,9 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 {
                     foreach ( var attribute in AttributeFilters )
                     {
-                        var filterControl = phFilterControls.FindControl( "filter_" + attribute.Id.ToString() );
-                        var filterPageParam = PageParameter( "filter_" + attribute.Id.ToString() );
+                        var filterId = $"filter_{attribute.Key}_{attribute.FieldType.Id}";
+                        var filterControl = phFilterControls.FindControl( filterId );
+                        var filterPageParam = PageParameter( filterId );
                         if ( !string.IsNullOrWhiteSpace( filterPageParam ) )
                         {
                             var filterParamList = filterPageParam.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ).ToList();


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Bug fix in Group Finder for URL Param based filters and hiding values not working.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed bug with URL Parameter filters not working in Group Finder. New Format: `filter_<attributeKey>_<attributeFieldTypeId>=<value>`
- Fixed bug with hiding attribute values no longer working.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/167491052-e8fc5af3-1e1e-4145-a25c-b79b1d5bbc85.png)

---------

### Change Log

##### What files does it affect?

- Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
