### PR TITLE
Dynamic Data Lava block

### DIFF
--- a/Reporting/DynamicDataLava.ascx
+++ b/Reporting/DynamicDataLava.ascx
@@ -33,14 +33,14 @@
                                 </div>
                             </div>
 
-                            <h3>Query/JSON Logic</h3>
+                            <h3>JSON Logic</h3>
                             <hr class="mt-0" />
                             <div class="row">
                                 <div class="col-md-12">
-                                    <Rock:CodeEditor ID="ceQuery" EditorHeight="212" EditorMode="Lava" EditorTheme="Rock" runat="server" Label="Query"
-                                        Help="The lava generated JSON object, must be a valid array JSON Object or what you would expect from '{{ <entity>Items | ToJSON }}' output.  If parameters are included they will also need to be in the Parameters field below.
+                                    <Rock:CodeEditor ID="ceQuery" EditorHeight="212" EditorMode="Lava" EditorTheme="Rock" runat="server" Label="JSON Lava"
+                                        Help="The Lava used to generate the JSON formatted output. Which can be as simple as using '{{ entityItems | ToJSON }}' output.  If parameters are included they will also need to be in the Parameters field below.
                                             By default, a grid will be displayed showing all the rows and columns returned by the query.  However, if a 'Formatted Output' value is included below, the results will be formatted
-                                            according to the 'Formatted Output' value." />
+                                            according to the 'Formatted Output' value. <small><span class='tip tip-lava'></span></small>" />
                                 </div>
                             </div>
 

--- a/Reporting/DynamicDataLava.ascx
+++ b/Reporting/DynamicDataLava.ascx
@@ -1,4 +1,4 @@
-﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="DynamicData.ascx.cs" Inherits="RockWeb.Blocks.Reporting.DynamicData" %>
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="DynamicDataLava.ascx.cs" Inherits="RockWeb.Plugins.rocks_kfs.Reporting.DynamicDataLava" %>
 
 <asp:UpdatePanel ID="upnlContent" runat="server" ChildrenAsTriggers="false" UpdateMode="Conditional">
     <ContentTemplate>
@@ -150,6 +150,10 @@
                                     <div class="col-md-12">
                                         <Rock:CodeEditor ID="cePageTitleLava" runat="server" Label="Page Title Lava" EditorMode="Lava" CssClass="input-large" EditorHeight="200"
                                             Help="Optional Lava for setting the page title. If nothing is provided then the page's title will be used. Example '{{rows[0].FullName}}' or if the query returns multiple result sets '{{table1.rows[0].FullName}}'." />
+                                        <Rock:CodeEditor ID="ceGridHeaderLava" runat="server" Label="Grid Header Content" EditorMode="Lava" CssClass="input-large" EditorHeight="200"
+                                            Help="This Lava template will be rendered above the grid. It will have access to the same dataset as the grid." />
+                                        <Rock:CodeEditor ID="ceGridFooterLava" runat="server" Label="Grid Footer Content" EditorMode="Lava" CssClass="input-large" EditorHeight="200"
+                                            Help="This Lava template will be rendered below the grid (best used for custom totaling). It will have access to the same dataset as the grid." />
                                     </div>
                                 </div>
                             </Rock:PanelWidget>

--- a/Reporting/DynamicDataLava.ascx
+++ b/Reporting/DynamicDataLava.ascx
@@ -6,6 +6,7 @@
         <%-- View Panel --%>
         <asp:Panel ID="pnlView" runat="server">
             <Rock:NotificationBox ID="nbError" runat="server" Title="Query Error!" NotificationBoxType="Danger" Visible="false" />
+            <asp:PlaceHolder ID="phQueryOutput" runat="server" Visible="false" />
             <asp:PlaceHolder ID="phContent" runat="server" Visible="false" />
         </asp:Panel>
 
@@ -32,12 +33,12 @@
                                 </div>
                             </div>
 
-                            <h3>Query Logic</h3>
+                            <h3>Query/JSON Logic</h3>
                             <hr class="mt-0" />
                             <div class="row">
                                 <div class="col-md-12">
-                                    <Rock:CodeEditor ID="ceQuery" EditorHeight="212" EditorMode="Sql" EditorTheme="Rock" runat="server" Label="Query"
-                                        Help="The SQL query or stored procedure name to execute.  If parameters are included they will also need to be in the Parameters field below.
+                                    <Rock:CodeEditor ID="ceQuery" EditorHeight="212" EditorMode="Lava" EditorTheme="Rock" runat="server" Label="Query"
+                                        Help="The lava generated JSON object, must be a valid array JSON Object or what you would expect from '{{ <entity>Items | ToJSON }}' output.  If parameters are included they will also need to be in the Parameters field below.
                                             By default, a grid will be displayed showing all the rows and columns returned by the query.  However, if a 'Formatted Output' value is included below, the results will be formatted
                                             according to the 'Formatted Output' value." />
                                 </div>
@@ -45,22 +46,12 @@
 
                             <div class="row">
                                 <div class="col-md-6">
-                                    <Rock:RockCheckBox ID="cbStoredProcedure" runat="server" Label="Query is a Stored Procedure" Help="Provide only the name of the stored procedure in the Query field. The parameters (if any) for the stored procedure should be configured using the Parameters field." />
-                                </div>
-                                <div class="col-md-6">
-                                    <div class="input-group">
-                                        <label>Timeout</label>
-                                        <div class="input-group input-width-md">
-                                            <Rock:NumberBox ID="nbTimeout" CssClass="form-control" runat="server" /><span class="input-group-addon">(sec)</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-md-6">
                                     <Rock:RockTextBox ID="tbParams" runat="server" Label="Parameters" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
                                         Help="The parameters that the query expects in the format of 'param1=value;param2=value'. The equals sign must be provided for each parameter, but you don't have to provide a default value if you want it to default to blank.  Any parameter with the same name as a page parameter (i.e. querystring,
                                             form, or page route) will have its value replaced with the page's current value.  A parameter with the name of 'CurrentPersonId' will have its value replaced with the currently logged in person's id." />
+                                </div>
+                                <div class="col-md-6">
+                                    <Rock:Switch ID="cbOutputQueryLava" runat="server" Text="Show Lava Output of Query for Debug purposes" CssClass="js-checkbox-output-query-lava" />
                                 </div>
                             </div>
 
@@ -104,7 +95,7 @@
                                 </div>
                             </div>
 
-                           <div class="row js-wrap-in-panel">
+                            <div class="row js-wrap-in-panel">
                                 <div class="col-md-6">
                                     <Rock:RockTextBox ID="tbPanelTitle" runat="server" Label="Panel Title" />
                                 </div>

--- a/Reporting/DynamicDataLava.ascx
+++ b/Reporting/DynamicDataLava.ascx
@@ -1,0 +1,201 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="DynamicData.ascx.cs" Inherits="RockWeb.Blocks.Reporting.DynamicData" %>
+
+<asp:UpdatePanel ID="upnlContent" runat="server" ChildrenAsTriggers="false" UpdateMode="Conditional">
+    <ContentTemplate>
+
+        <%-- View Panel --%>
+        <asp:Panel ID="pnlView" runat="server">
+            <Rock:NotificationBox ID="nbError" runat="server" Title="Query Error!" NotificationBoxType="Danger" Visible="false" />
+            <asp:PlaceHolder ID="phContent" runat="server" Visible="false" />
+        </asp:Panel>
+
+        <%-- Edit Panel --%>
+        <asp:Panel ID="pnlEditModel" runat="server" Visible="false">
+            <Rock:ModalDialog ID="mdEdit" runat="server" OnSaveClick="lbSave_Click" Title="Dynamic Data Block">
+                <Content>
+
+                    <asp:UpdatePanel runat="server" ID="upnlEdit">
+                        <ContentTemplate>
+
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <Rock:RockTextBox ID="tbName" runat="server" Label="Page Name" CssClass="input-large" Help="The current page's title" />
+                                </div>
+                                <div class="col-md-6">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <Rock:RockTextBox ID="tbDesc" runat="server" Label="Page Description" TextMode="MultiLine" Rows="1" CssClass="input-xlarge" Help="The current page's description" />
+                                </div>
+                                <div class="col-md-6">
+                                </div>
+                            </div>
+
+                            <h3>Query Logic</h3>
+                            <hr class="mt-0" />
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <Rock:CodeEditor ID="ceQuery" EditorHeight="212" EditorMode="Sql" EditorTheme="Rock" runat="server" Label="Query"
+                                        Help="The SQL query or stored procedure name to execute.  If parameters are included they will also need to be in the Parameters field below.
+                                            By default, a grid will be displayed showing all the rows and columns returned by the query.  However, if a 'Formatted Output' value is included below, the results will be formatted
+                                            according to the 'Formatted Output' value." />
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <Rock:RockCheckBox ID="cbStoredProcedure" runat="server" Label="Query is a Stored Procedure" Help="Provide only the name of the stored procedure in the Query field. The parameters (if any) for the stored procedure should be configured using the Parameters field." />
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="input-group">
+                                        <label>Timeout</label>
+                                        <div class="input-group input-width-md">
+                                            <Rock:NumberBox ID="nbTimeout" CssClass="form-control" runat="server" /><span class="input-group-addon">(sec)</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <Rock:RockTextBox ID="tbParams" runat="server" Label="Parameters" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
+                                        Help="The parameters that the query expects in the format of 'param1=value;param2=value'. The equals sign must be provided for each parameter, but you don't have to provide a default value if you want it to default to blank.  Any parameter with the same name as a page parameter (i.e. querystring,
+                                            form, or page route) will have its value replaced with the page's current value.  A parameter with the name of 'CurrentPersonId' will have its value replaced with the currently logged in person's id." />
+                                </div>
+                            </div>
+
+                            <h3>Formatting</h3>
+                            <hr class="mt-0" />
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="mb-3">
+                                        <div class="control-label">
+                                            <asp:DropDownList ID="ddlHideShow" runat="server" CssClass="input-small">
+                                                <asp:ListItem Text="Hide" Value="False"></asp:ListItem>
+                                                <asp:ListItem Text="Show" Value="True"></asp:ListItem>
+                                            </asp:DropDownList>
+                                            Columns<Rock:HelpBlock ID="hbHideShow" runat="server" Text="If using 'Show Columns,' only the columns specified will be displayed.  If using 'Hide Columns,' all columns except the columns specified will be displayed." />
+                                        </div>
+                                        <div>
+                                            <Rock:RockTextBox ID="tbColumns" runat="server" TextMode="MultiLine" Rows="1" CssClass="input-xlarge" />
+                                        </div>
+                                    </div>
+                                    <Rock:RockTextBox ID="tbUrlMask" runat="server" Label="Selection URL" CssClass="input-large"
+                                        Help="The URL to redirect user to when they click on a row in the grid.  Any column's value can be used in the URL by including it in braces.  For example if the grid includes an 'Id' column that contains Person Ids, you can link to the Person view, by specifying a value here of '~/Person/{Id}" />
+                                    <Rock:Switch ID="cbShowGridFilter" runat="server" Text="Show Grid Filter" TextAlign="Right" />
+                                    <Rock:Switch ID="swWrapInPanel" runat="server" Text="Wrap in Panel" CssClass="js-checkbox-wrap-in-panel" />
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="js-grid-options-container">
+                                        <Rock:Switch ID="cbPersonReport" runat="server" Text="Person Report" CssClass="js-checkbox-person-report"
+                                            Help="Does this query return a list of people? If it does, then additional options will be available from the result grid.  (i.e. Communicate, etc).  Note: A column named 'Id' that contains the person's Id is required for a person report." />
+                                        <Rock:RockControlWrapper ID="rcwGridOptions" runat="server" Label="Show Grid Actions">
+                                            <div class="margin-l-md">
+                                                <Rock:RockCheckBox ID="cbShowCommunicate" runat="server" ContainerCssClass="js-checkbox-person-grid-action" Text="Communicate" />
+                                                <Rock:RockCheckBox ID="cbShowMergePerson" runat="server" ContainerCssClass="js-checkbox-person-grid-action" Text="Merge Person" />
+                                                <Rock:RockCheckBox ID="cbShowBulkUpdate" runat="server" ContainerCssClass="js-checkbox-person-grid-action" Text="Bulk Update" />
+                                                <Rock:RockCheckBox ID="cbShowLaunchWorkflow" runat="server" ContainerCssClass="js-checkbox-person-grid-action" Text="Launch Workflow" />
+
+                                                <Rock:RockCheckBox ID="cbShowExcelExport" runat="server" Text="Excel Export" />
+                                                <Rock:RockCheckBox ID="cbShowMergeTemplate" runat="server" Text="Merge Template" />
+                                            </div>
+                                        </Rock:RockControlWrapper>
+                                    </div>
+                                </div>
+                            </div>
+
+                           <div class="row js-wrap-in-panel">
+                                <div class="col-md-6">
+                                    <Rock:RockTextBox ID="tbPanelTitle" runat="server" Label="Panel Title" />
+                                </div>
+                                <div class="col-md-6">
+                                    <Rock:RockTextBox ID="tbPanelIcon" runat="server" Label="Panel Icon CSS Class" />
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <Rock:Switch ID="swLavaCustomization" runat="server" Text="Customize Results with Lava" CssClass="js-checkbox-lava-customization" />
+                                </div>
+                            </div>
+                            <div class="row js-lava-customization">
+                                <div class="col-md-12">
+                                    <Rock:CodeEditor
+                                        ID="ceFormattedOutput"
+                                        runat="server"
+                                        Label="Formatted Output"
+                                        CssClass="input-large"
+                                        EditorHeight="400"
+                                        Help="Optional formatting to apply to the returned results.  If left blank, a grid will be displayed. Example: {% for row in rows %} {{ row.FirstName }} {% endfor %} or if the query returns multiple result sets: {% for row in table1.rows %} {{ row.FirstName }} {% endfor %} " />
+                                </div>
+                            </div>
+
+                            <Rock:PanelWidget CssClass="mt-4" runat="server" ID="pwAdvancedSettings" Title="Advanced Settings">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <Rock:RockTextBox ID="tbMergeFields" runat="server" Label="Communication Merge Fields" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
+                                            Help="When creating a new communication from a person report, additional fields from the report can be used as merge fields on the communication. Enter any column names that you'd like to be available for the communication. If the same recipient has multiple results in this report, each result will be included in an 'AdditionalFields' list. These can be accessed using Lava in the communication. For example: {% for field in AdditionalFields %}{{ field.columnName }}{% endfor %}" />
+
+                                    </div>
+                                    <div class="col-md-6">
+                                        <Rock:RockTextBox ID="tbCommunicationRecipientPersonIdFields" runat="server" Label="Communication Recipient Fields"
+                                            Help="The column name(s) that contain a person id field to use as the recipient for a communication. If left blank, it will assume a column named 'Id' contains the recipient's person Id." />
+                                    </div>
+                                    <div class="col-md-6">
+                                        <Rock:RockTextBox ID="tbEncryptedFields" runat="server" Label="Encrypted Fields" TextMode="MultiLine" Rows="1" CssClass="input-xlarge"
+                                            Help="Any fields that need to be decrypted before displaying their value." />
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <Rock:CodeEditor ID="cePageTitleLava" runat="server" Label="Page Title Lava" EditorMode="Lava" CssClass="input-large" EditorHeight="200"
+                                            Help="Optional Lava for setting the page title. If nothing is provided then the page's title will be used. Example '{{rows[0].FullName}}' or if the query returns multiple result sets '{{table1.rows[0].FullName}}'." />
+                                    </div>
+                                </div>
+                            </Rock:PanelWidget>
+                        </ContentTemplate>
+                    </asp:UpdatePanel>
+
+                </Content>
+            </Rock:ModalDialog>
+        </asp:Panel>
+        <script type="text/javascript">
+            function showHidePersonGridActions($personGridCheckbox) {
+                $personGridCheckbox.each(function (index, element) {
+                    if ($(element).is(':checked')) {
+                        $('.js-checkbox-person-grid-action').show();
+                    }
+                    else {
+                        $('.js-checkbox-person-grid-action').hide();
+                    }
+                })
+            };
+
+            function showHideItems(checkboxControl, controlsToHide) {
+                if (checkboxControl && checkboxControl.is(':checked')) {
+                    controlsToHide.show();
+                } else {
+                    controlsToHide.hide();
+                }
+            }
+
+            Sys.Application.add_load(function () {
+                showHidePersonGridActions($('.js-checkbox-person-report'));
+                showHideItems($('.js-checkbox-wrap-in-panel'), $(".js-wrap-in-panel"));
+                showHideItems($('.js-checkbox-lava-customization'), $(".js-lava-customization"));
+
+                $('.js-checkbox-person-report').on('change', function () {
+                    showHidePersonGridActions($(this));
+                })
+
+                $('.js-checkbox-wrap-in-panel').on('change', function () {
+                    showHideItems($(this), $(".js-wrap-in-panel"));
+                })
+
+                $('.js-checkbox-lava-customization').on('change', function () {
+                    showHideItems($(this), $(".js-lava-customization"));
+                })
+            });
+        </script>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/Reporting/DynamicDataLava.ascx.cs
+++ b/Reporting/DynamicDataLava.ascx.cs
@@ -1,0 +1,1240 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Web.UI;
+using System.Web.UI.HtmlControls;
+using System.Web.UI.WebControls;
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace RockWeb.Blocks.Reporting
+{
+    /// <summary>
+    /// Block to display dynamic report, html, xml, or transformed xml based on a SQL query or stored procedure.
+    /// </summary>
+    [DisplayName( "Dynamic Data" )]
+    [Category( "Reporting" )]
+    [Description( "Block to display dynamic report, html, xml, or transformed xml based on a SQL query or stored procedure." )]
+
+    #region Block Attributes
+    // Block Properties
+    [BooleanField( "Update Page",
+        Description = "If True, provides fields for updating the parent page's Name and Description",
+        DefaultBooleanValue = true,
+        Order = 0,
+        Key = AttributeKey.UpdatePage )]
+    [LavaCommandsField( "Enabled Lava Commands",
+        Description = "The Lava commands that should be enabled for this dynamic data block.",
+        IsRequired = false,
+        Order = 1,
+        Key = AttributeKey.EnabledLavaCommands )]
+    [BooleanField( "Enable Quick Return",
+        Description = "When enabled, viewing the block will cause it to be added to the Quick Return list in the bookmarks feature.",
+        DefaultBooleanValue = false,
+        Key = AttributeKey.EnableQuickReturn )]
+
+    // Custom Settings
+    [CodeEditorField( "Query",
+        Description = "The query to execute. Note that if you are providing SQL you can add items from the query string using Lava like {{ QueryParmName }}.",
+        EditorMode = CodeEditorMode.Sql,
+        EditorTheme = CodeEditorTheme.Rock,
+        EditorHeight = 400,
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.Query )]
+
+    [TextField( "Query Params",
+        Description = "Parameters to pass to query",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.QueryParams )]
+
+    [BooleanField( "Stored Procedure",
+        Description = "Is the query a stored procedure?",
+        DefaultBooleanValue = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.StoredProcedure )]
+
+    [TextField( "Url Mask",
+        Description = "The URL to redirect to when a row is clicked",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.UrlMask )]
+
+    [BooleanField( "Show Columns",
+        Description = "Should the 'Columns' specified below be the only ones shown (vs. the only ones hidden)",
+        DefaultBooleanValue = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowColumns )]
+
+    [TextField( "Columns",
+        Description = "The columns to hide or show",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.Columns )]
+
+    [CodeEditorField( "Formatted Output",
+        Description = "Optional formatting to apply to the returned results.  If left blank, a grid will be displayed. Example: {% for row in rows %} {{ row.FirstName }}<br/> {% endfor %}",
+        EditorMode = CodeEditorMode.Lava,
+        EditorTheme = CodeEditorTheme.Rock,
+        EditorHeight = 200,
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.FormattedOutput )]
+
+    [BooleanField( "Person Report",
+        Description = "Is this report a list of people?",
+        DefaultBooleanValue = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.PersonReport )]
+
+    [BooleanField( "Show Communicate",
+        Description = "Show Communicate button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowCommunicate )]
+
+    [BooleanField( "Show Merge Person",
+        Description = "Show Merge Person button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowMergePerson )]
+
+    [BooleanField( "Show Bulk Update",
+        Description = "Show Bulk Update button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowBulkUpdate )]
+
+    [BooleanField( "Show Excel Export",
+        Description = "Show Export to Excel button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowExcelExport )]
+
+    [BooleanField( "Show Merge Template",
+        Description = "Show Export to Merge Template button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowMergeTemplate )]
+
+    [BooleanField( "Show Launch Workflow",
+        Description = "Show Launch Workflow button in grid footer?",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowLaunchWorkflow )]
+
+    [IntegerField( "Timeout",
+        Description = "The amount of time in seconds to allow the query to run before timing out.",
+        IsRequired = false,
+        DefaultIntegerValue = 30,
+        Category = "CustomSetting",
+        Key = AttributeKey.Timeout )]
+
+    [TextField( "Merge Fields",
+        Description = "Any fields to make available as merge fields for any new communications",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.MergeFields )]
+
+    [TextField( "Communication Recipient Person Id Columns",
+        Description = "Columns that contain a communication recipient person id.",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.CommunicationRecipientPersonIdColumns )]
+
+    [TextField( "Encrypted Fields",
+        Description = "Any fields that need to be decrypted before displaying their value",
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.EncryptedFields )]
+
+    [CodeEditorField( "Page Title Lava",
+        Description = "Optional Lava for setting the page title. If nothing is provided then the page's title will be used.",
+        EditorMode = CodeEditorMode.Lava,
+        EditorTheme = CodeEditorTheme.Rock,
+        EditorHeight = 200,
+        IsRequired = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.PageTitleLava )]
+
+    [BooleanField( "Paneled Grid",
+        Description = "Add the 'grid-panel' class to the grid to allow it to fit nicely in a block.",
+        DefaultBooleanValue = false,
+        Category = "Advanced",
+        Key = AttributeKey.PaneledGrid )]
+
+    [BooleanField( "Show Grid Filter",
+        Description = "Show filtering controls that are dynamically generated to match the columns of the dynamic data.",
+        DefaultBooleanValue = true,
+        Category = "CustomSetting",
+        Key = AttributeKey.ShowGridFilter )]
+
+    [BooleanField( "Wrap In Panel",
+        Description = "This will wrap the results grid in a panel.",
+        DefaultBooleanValue = false,
+        Category = "CustomSetting",
+        Key = AttributeKey.WrapInPanel )]
+
+    [TextField( "Panel Title",
+        Description = "The title of the panel.",
+        Category = "CustomSetting",
+        Key = AttributeKey.PanelTitle )]
+
+    [TextField( "Panel Icon CSS Class",
+        Description = "The CSS Class to use in the panel title.",
+        Category = "CustomSetting",
+        Key = AttributeKey.PanelTitleCssClass )]
+
+    #endregion
+    public partial class DynamicData : RockBlockCustomSettings
+    {
+        #region Keys
+
+        /// <summary>
+        /// Attribute Keys
+        /// </summary>
+        private static class AttributeKey
+        {
+            public const string UpdatePage = "UpdatePage";
+            public const string EnabledLavaCommands = "EnabledLavaCommands";
+            public const string Query = "Query";
+            public const string QueryParams = "QueryParams";
+            public const string StoredProcedure = "StoredProcedure";
+            public const string UrlMask = "UrlMask";
+            public const string ShowColumns = "ShowColumns";
+            public const string Columns = "Columns";
+            public const string FormattedOutput = "FormattedOutput";
+            public const string PersonReport = "PersonReport";
+            public const string ShowCommunicate = "ShowCommunicate";
+            public const string ShowMergePerson = "ShowMergePerson";
+            public const string ShowBulkUpdate = "ShowBulkUpdate";
+            public const string ShowExcelExport = "ShowExcelExport";
+            public const string ShowMergeTemplate = "ShowMergeTemplate";
+            public const string Timeout = "Timeout";
+            public const string MergeFields = "MergeFields";
+            public const string CommunicationRecipientPersonIdColumns = "CommunicationRecipientPersonIdColumns";
+            public const string EncryptedFields = "EncryptedFields";
+            public const string PageTitleLava = "PageTitleLava";
+            public const string PaneledGrid = "PaneledGrid";
+            public const string ShowGridFilter = "ShowGridFilter";
+            public const string WrapInPanel = "WrapInPanel";
+            public const string PanelTitle = "PanelTitle";
+            public const string PanelTitleCssClass = "PanelTitleCssClass";
+            public const string ShowLaunchWorkflow = "ShowLaunchWorkflow";
+            public const string EnableQuickReturn = "EnableQuickReturn";
+        }
+
+        #endregion Keys
+
+        #region Fields
+
+        private Dictionary<int, string> _sortExpressions = new Dictionary<int, string>();
+        private bool _updatePage = true;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the GridFilter.
+        /// </summary>
+        public GridFilter GridFilter { get; set; }
+        public Dictionary<Control, string> GridFilterColumnLookup;
+
+        /// <summary>
+        /// Gets the settings tool tip.
+        /// </summary>
+        /// <value>
+        /// The settings tool tip.
+        /// </value>
+        public override string SettingsToolTip
+        {
+            get
+            {
+                return "Edit Criteria";
+            }
+        }
+
+        #endregion
+
+        #region Base Control Methods
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            BlockUpdated += DynamicData_BlockUpdated;
+            AddConfigurationUpdateTrigger( upnlContent );
+
+            BuildControls( !Page.IsPostBack );
+
+            _updatePage = GetAttributeValue( AttributeKey.UpdatePage ).AsBoolean( true );
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Displays the text of the current filters
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The e.</param>
+        protected void DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
+        {
+            DateTime startDateTimeValue;
+            DateTime endDateTimeValue;
+
+            if ( DateRangePicker.TryParse( e.Value, out startDateTimeValue, out endDateTimeValue ) )
+            {
+                e.Value = DateRangePicker.FormatDelimitedValues( e.Value );
+            }
+        }
+
+        /// <summary>
+        /// Handles the ApplyFilterClick event of the fDevice control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
+        protected void ApplyFilterClick( object sender, EventArgs e )
+        {
+            GridFilter.DeleteUserPreferences();
+
+            foreach ( Control control in GridFilter.Controls )
+            {
+                var key = control.ID;
+                string value = null;
+                string name = null;
+
+                if ( control is DateRangePicker )
+                {
+                    var dateRangePicker = control as DateRangePicker;
+
+                    if ( dateRangePicker.UpperValue.HasValue && dateRangePicker.LowerValue.HasValue )
+                    {
+                        value = dateRangePicker.DelimitedValues;
+                        name = key.Remove( 0, 3 ).SplitCase();
+                    }
+                }
+                else if ( control is RockDropDownList )
+                {
+                    var dropDownList = control as RockDropDownList;
+                    value = dropDownList.SelectedValue;
+                    name = key.Remove( 0, 3 ).SplitCase();
+                }
+                else if ( control is RockTextBox )
+                {
+                    var textBox = control as RockTextBox;
+                    value = textBox.Text;
+                    name = key.Remove( 0, 2 ).SplitCase();
+                }
+
+                GridFilter.SaveUserPreference( key, name, value );
+            }
+
+            gReport_GridRebind( sender, e );
+        }
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the DynamicData control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void DynamicData_BlockUpdated( object sender, EventArgs e )
+        {
+            BuildControls( true );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbSave control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbSave_Click( object sender, EventArgs e )
+        {
+            if ( _updatePage )
+            {
+                var pageCache = PageCache.Get( RockPage.PageId );
+                if ( pageCache != null &&
+                    ( pageCache.PageTitle != tbName.Text || pageCache.Description != tbDesc.Text ) )
+                {
+                    var rockContext = new RockContext();
+                    var service = new PageService( rockContext );
+                    var page = service.Get( pageCache.Id );
+                    page.InternalName = tbName.Text;
+                    page.PageTitle = tbName.Text;
+                    page.BrowserTitle = tbName.Text;
+                    page.Description = tbDesc.Text;
+                    rockContext.SaveChanges();
+
+                    pageCache = PageCache.Get( RockPage.PageId );
+
+                    var breadCrumb = RockPage.BreadCrumbs.Where( c => c.Url == RockPage.PageReference.BuildUrl() ).FirstOrDefault();
+                    if ( breadCrumb != null )
+                    {
+                        breadCrumb.Name = pageCache.BreadCrumbText;
+                    }
+                }
+            }
+
+            SetAttributeValue( AttributeKey.Query, ceQuery.Text );
+            SetAttributeValue( AttributeKey.Timeout, nbTimeout.Text );
+            SetAttributeValue( AttributeKey.StoredProcedure, cbStoredProcedure.Checked.ToString() );
+            SetAttributeValue( AttributeKey.QueryParams, tbParams.Text );
+            SetAttributeValue( AttributeKey.UrlMask, tbUrlMask.Text );
+            SetAttributeValue( AttributeKey.Columns, tbColumns.Text );
+            SetAttributeValue( AttributeKey.ShowColumns, ddlHideShow.SelectedValue );
+            SetAttributeValue( AttributeKey.FormattedOutput, ceFormattedOutput.Text );
+            SetAttributeValue( AttributeKey.PageTitleLava, cePageTitleLava.Text );
+            SetAttributeValue( AttributeKey.PersonReport, cbPersonReport.Checked.ToString() );
+            SetAttributeValue( AttributeKey.CommunicationRecipientPersonIdColumns, tbCommunicationRecipientPersonIdFields.Text );
+            SetAttributeValue( AttributeKey.ShowCommunicate, ( cbPersonReport.Checked && cbShowCommunicate.Checked ).ToString() );
+            SetAttributeValue( AttributeKey.ShowMergePerson, ( cbPersonReport.Checked && cbShowMergePerson.Checked ).ToString() );
+            SetAttributeValue( AttributeKey.ShowBulkUpdate, ( cbPersonReport.Checked && cbShowBulkUpdate.Checked ).ToString() );
+            SetAttributeValue( AttributeKey.ShowExcelExport, cbShowExcelExport.Checked.ToString() );
+            SetAttributeValue( AttributeKey.ShowMergeTemplate, cbShowMergeTemplate.Checked.ToString() );
+            SetAttributeValue( AttributeKey.ShowLaunchWorkflow, ( cbPersonReport.Checked && cbShowLaunchWorkflow.Checked ).ToString() );
+            SetAttributeValue( AttributeKey.ShowGridFilter, cbShowGridFilter.Checked.ToString() );
+            SetAttributeValue( AttributeKey.MergeFields, tbMergeFields.Text );
+            SetAttributeValue( AttributeKey.EncryptedFields, tbEncryptedFields.Text );
+            SetAttributeValue( AttributeKey.WrapInPanel, swWrapInPanel.Checked.ToString() );
+            SetAttributeValue( AttributeKey.PanelTitleCssClass, tbPanelIcon.Text );
+            SetAttributeValue( AttributeKey.PanelTitle, tbPanelTitle.Text );
+            SaveAttributeValues();
+
+            mdEdit.Hide();
+            pnlEditModel.Visible = false;
+            upnlContent.Update();
+
+            BuildControls( true );
+        }
+
+        /// <summary>
+        /// Handles the RowSelected event of the gReport control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
+        protected void gReport_RowSelected( object sender, RowEventArgs e )
+        {
+            Grid grid = sender as Grid;
+            string url = GetAttributeValue( AttributeKey.UrlMask );
+            if ( grid != null && !string.IsNullOrWhiteSpace( url ) )
+            {
+                foreach ( string key in grid.DataKeyNames )
+                {
+                    url = url.Replace( "{" + key + "}", grid.DataKeys[e.RowIndex][key].ToString() );
+                }
+
+                Response.Redirect( url, false );
+            }
+        }
+
+        /// <summary>
+        /// Handles the GridRebind event of the gReport control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void gReport_GridRebind( object sender, EventArgs e )
+        {
+            string errorMessage = string.Empty;
+            var ds = GetData( out errorMessage );
+            if ( ds != null )
+            {
+                int i = 0;
+                foreach ( Control div in phContent.Controls )
+                {
+                    foreach ( var grid in div.ControlsOfTypeRecursive<Grid>() )
+                    {
+                        if ( ds.Tables.Count > i )
+                        {
+                            FilterTable( grid, ds.Tables[i] );
+                            SortTable( grid, ds.Tables[i] );
+                            grid.DataSource = ds.Tables[i];
+                            grid.DataBind();
+                            i++;
+                        }
+                    }
+                }
+            }
+
+            upnlContent.Update();
+        }
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// Gets the data.
+        /// </summary>
+        /// <param name="errorMessage">The error message.</param>
+        /// <param name="schemaOnly">if set to <c>true</c> [schema only].</param>
+        /// <returns></returns>
+        private DataSet GetData( out string errorMessage, bool schemaOnly = false )
+        {
+            errorMessage = string.Empty;
+
+            string query = GetAttributeValue( AttributeKey.Query );
+            string enabledLavaCommands = this.GetAttributeValue( AttributeKey.EnabledLavaCommands );
+            if ( !string.IsNullOrWhiteSpace( query ) )
+            {
+                try
+                {
+                    var mergeFields = GetDynamicDataMergeFields();
+
+                    // NOTE: there is already a PageParameters merge field from GetDynamicDataMergeFields, but for backwords compatibility, also add each of the PageParameters as plain merge fields
+                    foreach ( var pageParam in PageParameters() )
+                    {
+                        mergeFields.AddOrReplace( pageParam.Key, pageParam.Value );
+                    }
+
+                    query = query.ResolveMergeFields( mergeFields, enabledLavaCommands );
+
+                    var parameters = GetParameters();
+                    int timeout = GetAttributeValue( AttributeKey.Timeout ).AsInteger();
+
+                    if ( schemaOnly )
+                    {
+                        try
+                        {
+                            // GetDataSetSchema won't work in some cases, for example, if the SQL references a TEMP table.  So, fall back to use the regular GetDataSet if there is an exception or the schema does not return any tables
+                            var dataSet = DbService.GetDataSetSchema( query, GetAttributeValue( AttributeKey.StoredProcedure ).AsBoolean( false ) ? CommandType.StoredProcedure : CommandType.Text, parameters, timeout );
+                            if ( dataSet != null && dataSet.Tables != null && dataSet.Tables.Count > 0 )
+                            {
+                                return dataSet;
+                            }
+                            else
+                            {
+                                return DbService.GetDataSet( query, GetAttributeValue( AttributeKey.StoredProcedure ).AsBoolean( false ) ? CommandType.StoredProcedure : CommandType.Text, parameters, timeout );
+                            }
+                        }
+                        catch
+                        {
+                            return DbService.GetDataSet( query, GetAttributeValue( AttributeKey.StoredProcedure ).AsBoolean( false ) ? CommandType.StoredProcedure : CommandType.Text, parameters, timeout );
+                        }
+                    }
+                    else
+                    {
+                        return DbService.GetDataSet( query, GetAttributeValue( AttributeKey.StoredProcedure ).AsBoolean( false ) ? CommandType.StoredProcedure : CommandType.Text, parameters, timeout );
+                    }
+                }
+                catch ( System.Exception ex )
+                {
+                    errorMessage = ex.Message;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Shows the settings.
+        /// </summary>
+        protected override void ShowSettings()
+        {
+            pnlEditModel.Visible = true;
+            upnlContent.Update();
+            mdEdit.Show();
+
+            if ( _updatePage )
+            {
+                var pageCache = PageCache.Get( RockPage.PageId );
+                tbName.Text = pageCache != null ? pageCache.PageTitle : string.Empty;
+                tbDesc.Text = pageCache != null ? pageCache.Description : string.Empty;
+            }
+
+            tbName.Visible = _updatePage;
+            tbDesc.Visible = _updatePage;
+
+            ceQuery.Text = GetAttributeValue( AttributeKey.Query );
+            nbTimeout.Text = GetAttributeValue( AttributeKey.Timeout );
+            cbStoredProcedure.Checked = GetAttributeValue( AttributeKey.StoredProcedure ).AsBoolean();
+            tbParams.Text = GetAttributeValue( AttributeKey.QueryParams );
+            tbUrlMask.Text = GetAttributeValue( AttributeKey.UrlMask );
+            ddlHideShow.SelectedValue = GetAttributeValue( AttributeKey.ShowColumns );
+            tbColumns.Text = GetAttributeValue( AttributeKey.Columns );
+            ceFormattedOutput.Text = GetAttributeValue( AttributeKey.FormattedOutput );
+            cePageTitleLava.Text = GetAttributeValue( AttributeKey.PageTitleLava );
+            cbPersonReport.Checked = GetAttributeValue( AttributeKey.PersonReport ).AsBoolean();
+            tbCommunicationRecipientPersonIdFields.Text = GetAttributeValue( AttributeKey.CommunicationRecipientPersonIdColumns );
+            cbShowCommunicate.Checked = GetAttributeValue( AttributeKey.ShowCommunicate ).AsBoolean();
+            cbShowMergePerson.Checked = GetAttributeValue( AttributeKey.ShowMergePerson ).AsBoolean();
+            cbShowBulkUpdate.Checked = GetAttributeValue( AttributeKey.ShowBulkUpdate ).AsBoolean();
+            cbShowExcelExport.Checked = GetAttributeValue( AttributeKey.ShowExcelExport ).AsBoolean();
+            cbShowMergeTemplate.Checked = GetAttributeValue( AttributeKey.ShowMergeTemplate ).AsBoolean();
+            cbShowLaunchWorkflow.Checked = GetAttributeValue( AttributeKey.ShowLaunchWorkflow ).AsBoolean();
+            cbShowGridFilter.Checked = GetAttributeValue( AttributeKey.ShowGridFilter ).AsBoolean();
+            tbMergeFields.Text = GetAttributeValue( AttributeKey.MergeFields );
+            tbEncryptedFields.Text = GetAttributeValue( AttributeKey.EncryptedFields );
+            swWrapInPanel.Checked = GetAttributeValue( AttributeKey.WrapInPanel ).AsBoolean();
+            tbPanelIcon.Text = GetAttributeValue( AttributeKey.PanelTitleCssClass );
+            tbPanelTitle.Text = GetAttributeValue( AttributeKey.PanelTitle );
+            swLavaCustomization.Checked = ceFormattedOutput.Text.IsNotNullOrWhiteSpace();
+
+        }
+
+        /// <summary>
+        /// Gets the dynamic data merge fields.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<string, object> GetDynamicDataMergeFields()
+        {
+            var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
+            if ( CurrentPerson != null )
+            {
+                // TODO: When support for "Person" is not supported anymore (should use "CurrentPerson" instead), remove this line
+                mergeFields.Add( "Person", CurrentPerson );
+            }
+
+            mergeFields.Add( "RockVersion", Rock.VersionInfo.VersionInfo.GetRockProductVersionNumber() );
+            mergeFields.Add( "CurrentPage", this.PageCache );
+
+            return mergeFields;
+        }
+
+        /// <summary>
+        /// Builds the controls.
+        /// </summary>
+        /// <param name="setData">if set to <c>true</c> [set data].</param>
+        private void BuildControls( bool setData )
+        {
+            var showGridFilterControls = GetAttributeValue( AttributeKey.ShowGridFilter ).AsBoolean();
+            string enabledLavaCommands = this.GetAttributeValue( AttributeKey.EnabledLavaCommands );
+            string errorMessage = string.Empty;
+
+            // get just the schema of the data until we actually need the data
+            var dataSetSchema = GetData( out errorMessage, true );
+
+            if ( !string.IsNullOrWhiteSpace( errorMessage ) )
+            {
+                phContent.Visible = false;
+
+                nbError.Text = errorMessage;
+                nbError.Visible = true;
+            }
+            else
+            {
+                phContent.Controls.Clear();
+
+                var mergeFields = GetDynamicDataMergeFields();
+
+                if ( dataSetSchema != null )
+                {
+                    string formattedOutput = GetAttributeValue( AttributeKey.FormattedOutput );
+
+                    // load merge objects if needed by either for formatted output OR page title
+                    if ( !string.IsNullOrWhiteSpace( GetAttributeValue( AttributeKey.PageTitleLava ) ) || !string.IsNullOrWhiteSpace( formattedOutput ) )
+                    {
+                        int i = 1;
+
+                        // Formatted output needs all the rows, so get the data regardless of the setData parameter
+                        var dataSet = GetData( out errorMessage );
+
+                        if ( dataSet == null || dataSet.Tables == null )
+                        {
+
+                            nbError.Text = errorMessage;
+                            nbError.Visible = true;
+                            return;
+                        }
+
+                        foreach ( DataTable dataTable in dataSet.Tables )
+                        {
+                            var dropRows = new List<DataRowDrop>();
+                            foreach ( DataRow row in dataTable.Rows )
+                            {
+                                dropRows.Add( new DataRowDrop( row ) );
+                            }
+
+                            if ( dataSet.Tables.Count > 1 )
+                            {
+                                var tableField = new Dictionary<string, object>();
+                                tableField.Add( "rows", dropRows );
+                                mergeFields.Add( "table" + i.ToString(), tableField );
+                            }
+                            else
+                            {
+                                mergeFields.Add( "rows", dropRows );
+                            }
+                            i++;
+                        }
+                    }
+
+                    // set page title
+                    if ( !string.IsNullOrWhiteSpace( GetAttributeValue( AttributeKey.PageTitleLava ) ) )
+                    {
+                        string title = GetAttributeValue( AttributeKey.PageTitleLava ).ResolveMergeFields( mergeFields, enabledLavaCommands );
+
+                        RockPage.BrowserTitle = title;
+                        RockPage.PageTitle = title;
+                        RockPage.Header.Title = title;
+                    }
+
+                    if ( GetAttributeValue( AttributeKey.EnableQuickReturn ).AsBoolean() && setData && RockPage.PageTitle.IsNotNullOrWhiteSpace() )
+                    {
+                        string quickReturnLava = "{{ Title | AddQuickReturn:'Dynamic Data', 80 }}";
+                        var quickReturnMergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson, new Rock.Lava.CommonMergeFieldsOptions { GetLegacyGlobalMergeFields = false } );
+                        quickReturnMergeFields.Add( "Title", RockPage.PageTitle );
+                        quickReturnLava.ResolveMergeFields( quickReturnMergeFields );
+                    }
+
+                    if ( string.IsNullOrWhiteSpace( formattedOutput ) )
+                    {
+                        bool personReport = GetAttributeValue( AttributeKey.PersonReport ).AsBoolean();
+
+                        int tableId = 0;
+                        DataSet dataSet;
+                        if ( setData == false )
+                        {
+                            dataSet = dataSetSchema;
+                        }
+                        else
+                        {
+                            dataSet = GetData( out errorMessage );
+                        }
+
+                        if ( dataSet == null || dataSet.Tables == null )
+                        {
+
+                            nbError.Text = errorMessage;
+                            nbError.Visible = true;
+                            return;
+                        }
+
+                        HtmlGenericControl divPanelBody = null;
+                        if ( GetAttributeValue( AttributeKey.WrapInPanel ).AsBoolean() )
+                        {
+                            var divPanel = new HtmlGenericControl( "div" );
+                            divPanel.AddCssClass( "panel panel-block" );
+
+                            var divPanelHeading = new HtmlGenericControl( "div" );
+                            divPanelHeading.AddCssClass( "panel-heading" );
+
+                            var panelIcon = GetAttributeValue( AttributeKey.PanelTitleCssClass );
+                            var panelTitle = GetAttributeValue( AttributeKey.PanelTitle );
+                            var hPanelTitle = new HtmlGenericControl( "h1" );
+                            hPanelTitle.AddCssClass( "panel-title" );
+                            divPanelHeading.Controls.Add( hPanelTitle );
+
+                            if ( panelIcon.IsNullOrWhiteSpace() )
+                            {
+                                hPanelTitle.InnerText = panelTitle;
+                            }
+                            else
+                            {
+                                var iPanelHeaderIcon = new HtmlGenericControl( "i" );
+                                iPanelHeaderIcon.AddCssClass( panelIcon );
+
+                                var spanPanelHeaderText = new HtmlGenericControl( "span" );
+                                spanPanelHeaderText.InnerText = " " + panelTitle;
+                                hPanelTitle.Controls.Add( iPanelHeaderIcon );
+                                hPanelTitle.Controls.Add( spanPanelHeaderText );
+                            }
+
+
+                            divPanelBody = new HtmlGenericControl( "div" );
+                            divPanelBody.AddCssClass( "panel-body" );
+
+                            divPanel.Controls.Add( divPanelHeading );
+                            divPanel.Controls.Add( divPanelBody );
+
+                            phContent.Controls.Add( divPanel );
+                        }
+
+                        foreach ( DataTable dataTable in dataSet.Tables )
+                        {
+                            var div = new HtmlGenericControl( "div" );
+                            div.AddCssClass( "grid" );
+
+                            if ( GetAttributeValue( AttributeKey.PaneledGrid ).AsBoolean() || GetAttributeValue( AttributeKey.WrapInPanel ).AsBoolean() )
+                            {
+                                div.AddCssClass( "grid-panel" );
+                            }
+
+                            if ( divPanelBody == null )
+                            {
+                                phContent.Controls.Add( div );
+                            }
+                            else
+                            {
+                                divPanelBody.Controls.Add( div );
+                            }
+
+                            GridFilter = new GridFilter()
+                            {
+                                ID = string.Format( "gfFilter{0}", tableId )
+                            };
+
+                            div.Controls.Add( GridFilter );
+                            GridFilter.ApplyFilterClick += ApplyFilterClick;
+                            GridFilter.DisplayFilterValue += DisplayFilterValue;
+                            GridFilter.Visible = showGridFilterControls && ( dataSet.Tables.Count == 1 );
+
+                            var grid = new Grid();
+                            div.Controls.Add( grid );
+                            grid.ID = string.Format( "dynamic_data_{0}", tableId++ );
+                            grid.AllowSorting = true;
+                            grid.EmptyDataText = "No Results";
+                            grid.Actions.ShowCommunicate = GetAttributeValue( AttributeKey.ShowCommunicate ).AsBoolean();
+                            grid.Actions.ShowMergePerson = GetAttributeValue( AttributeKey.ShowMergePerson ).AsBoolean();
+                            grid.Actions.ShowBulkUpdate = GetAttributeValue( AttributeKey.ShowBulkUpdate ).AsBoolean();
+                            grid.Actions.ShowExcelExport = GetAttributeValue( AttributeKey.ShowExcelExport ).AsBoolean();
+                            grid.Actions.ShowMergeTemplate = GetAttributeValue( AttributeKey.ShowMergeTemplate ).AsBoolean();
+                            grid.ShowWorkflowOrCustomActionButtons = GetAttributeValue( AttributeKey.ShowLaunchWorkflow ).AsBoolean();
+
+                            grid.GridRebind += gReport_GridRebind;
+                            grid.RowSelected += gReport_RowSelected;
+                            if ( personReport )
+                            {
+                                grid.PersonIdField = "Id";
+                            }
+                            else
+                            {
+                                grid.PersonIdField = null;
+                            }
+
+                            grid.CommunicateMergeFields = GetAttributeValue( AttributeKey.MergeFields ).SplitDelimitedValues().ToList<string>();
+                            grid.CommunicationRecipientPersonIdFields = GetAttributeValue( AttributeKey.CommunicationRecipientPersonIdColumns ).SplitDelimitedValues().ToList();
+
+                            AddGridColumns( grid, dataTable );
+                            SetDataKeyNames( grid, dataTable );
+
+                            if ( setData )
+                            {
+                                FilterTable( grid, dataTable );
+                                SortTable( grid, dataTable );
+                                grid.DataSource = dataTable;
+
+                                if ( personReport )
+                                {
+                                    grid.EntityTypeId = EntityTypeCache.GetId<Person>();
+                                }
+
+                                grid.DataBind();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        phContent.Controls.Add( new LiteralControl( formattedOutput.ResolveMergeFields( mergeFields, enabledLavaCommands ) ) );
+                    }
+                }
+
+                phContent.Visible = true;
+                nbError.Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the data key names.
+        /// </summary>
+        private void SetDataKeyNames( Grid grid, DataTable dataTable )
+        {
+            string urlMask = GetAttributeValue( AttributeKey.UrlMask );
+            if ( !string.IsNullOrWhiteSpace( urlMask ) )
+            {
+                Regex pattern = new Regex( @"\{[\w\s]+\}" );
+                var matches = pattern.Matches( urlMask );
+                if ( matches.Count > 0 )
+                {
+                    var keyNames = new List<string>();
+                    for ( int i = 0; i < matches.Count; i++ )
+                    {
+                        string colName = matches[i].Value.TrimStart( '{' ).TrimEnd( '}' );
+                        if ( dataTable.Columns.Contains( colName ) )
+                        {
+                            keyNames.Add( colName );
+                        }
+                    }
+
+                    grid.DataKeyNames = keyNames.ToArray();
+                }
+            }
+            else
+            {
+                if ( dataTable.Columns.Contains( "Id" ) )
+                {
+                    grid.DataKeyNames = new string[1] { "Id" };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the parameters.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<string, object> GetParameters()
+        {
+            string[] queryParams = GetAttributeValue( AttributeKey.QueryParams ).SplitDelimitedValues();
+            if ( queryParams.Length > 0 )
+            {
+                var parameters = new Dictionary<string, object>();
+                foreach ( string queryParam in queryParams )
+                {
+                    string[] paramParts = queryParam.Split( '=' );
+                    if ( paramParts.Length == 2 )
+                    {
+                        string queryParamName = paramParts[0];
+                        string queryParamValue = paramParts[1];
+
+                        // Remove leading '@' character if was included
+                        if ( queryParamName.StartsWith( "@" ) )
+                        {
+                            queryParamName = queryParamName.Substring( 1 );
+                        }
+
+                        // If a page parameter (query or form) value matches, use it's value instead
+                        string pageValue = PageParameter( queryParamName );
+                        if ( !string.IsNullOrWhiteSpace( pageValue ) )
+                        {
+                            queryParamValue = pageValue;
+                        }
+                        else if ( queryParamName.ToLower() == "currentpersonid" && CurrentPerson != null )
+                        {
+                            // If current person id, use the value of the current person id
+                            queryParamValue = CurrentPerson.Id.ToString();
+                        }
+
+                        parameters.Add( queryParamName, queryParamValue );
+                    }
+                }
+
+                return parameters;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Adds the grid columns.
+        /// </summary>
+        /// <param name="dataTable">The data table.</param>
+        private void AddGridColumns( Grid grid, DataTable dataTable )
+        {
+            bool showColumns = GetAttributeValue( AttributeKey.ShowColumns ).AsBoolean();
+            var columnList = GetAttributeValue( AttributeKey.Columns ).SplitDelimitedValues().ToList();
+            var encryptedFields = GetAttributeValue( AttributeKey.EncryptedFields ).SplitDelimitedValues().ToList();
+
+            int rowsToEval = 10;
+            if ( dataTable.Rows.Count < 10 )
+            {
+                rowsToEval = dataTable.Rows.Count;
+            }
+
+            grid.Columns.Clear();
+
+            if ( !string.IsNullOrWhiteSpace( grid.PersonIdField ) )
+            {
+                grid.Columns.Add( new SelectField() );
+            }
+
+            GridFilterColumnLookup = new Dictionary<Control, string>();
+
+            foreach ( DataColumn dataTableColumn in dataTable.Columns )
+            {
+                if ( columnList.Count > 0 &&
+                    ( ( showColumns && !columnList.Contains( dataTableColumn.ColumnName, StringComparer.OrdinalIgnoreCase ) ) ||
+                        ( !showColumns && columnList.Contains( dataTableColumn.ColumnName, StringComparer.OrdinalIgnoreCase ) ) ) )
+                {
+                    continue;
+                }
+
+                BoundField bf = new BoundField();
+                var splitCaseName = dataTableColumn.ColumnName.SplitCase();
+
+                if ( dataTableColumn.DataType == typeof( bool ) )
+                {
+                    bf = new BoolField();
+
+                    if ( GridFilter != null )
+                    {
+                        var id = "ddl" + dataTableColumn.ColumnName.RemoveSpecialCharacters();
+
+                        var filterControl = new RockDropDownList()
+                        {
+                            Label = splitCaseName,
+                            ID = id
+                        };
+
+                        GridFilterColumnLookup.Add( filterControl, dataTableColumn.ColumnName );
+
+                        filterControl.Items.Add( BoolToString( null ) );
+                        filterControl.Items.Add( BoolToString( true ) );
+                        filterControl.Items.Add( BoolToString( false ) );
+                        GridFilter.Controls.Add( filterControl );
+
+                        var value = GridFilter.GetUserPreference( id );
+
+                        if ( value != null )
+                        {
+                            filterControl.SetValue( value );
+                        }
+                    }
+                }
+                else if ( dataTableColumn.DataType == typeof( DateTime ) )
+                {
+                    bf = new DateField();
+
+                    for ( int i = 0; i < rowsToEval; i++ )
+                    {
+                        object dateObj = dataTable.Rows[i][dataTableColumn];
+                        if ( dateObj is DateTime )
+                        {
+                            DateTime dateTime = ( DateTime ) dateObj;
+                            if ( dateTime.TimeOfDay.TotalSeconds != 0 )
+                            {
+                                bf = new DateTimeField();
+                                break;
+                            }
+                        }
+                    }
+
+                    if ( GridFilter != null )
+                    {
+                        var id = "drp" + dataTableColumn.ColumnName.RemoveSpecialCharacters();
+
+                        var filterControl = new DateRangePicker()
+                        {
+                            Label = splitCaseName,
+                            ID = id,
+                        };
+
+                        GridFilterColumnLookup.Add( filterControl, dataTableColumn.ColumnName );
+
+                        GridFilter.Controls.Add( filterControl );
+
+                        var value = GridFilter.GetUserPreference( id );
+
+                        if ( value != null )
+                        {
+                            DateTime upper;
+                            DateTime lower;
+
+                            if ( DateRangePicker.TryParse( value, out lower, out upper ) )
+                            {
+                                filterControl.LowerValue = lower;
+                                filterControl.UpperValue = upper;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    if ( encryptedFields.Contains( dataTableColumn.ColumnName ) )
+                    {
+                        bf = new EncryptedField();
+                    }
+
+                    bf.HtmlEncode = false;
+
+                    if ( GridFilter != null )
+                    {
+                        var id = "tb" + dataTableColumn.ColumnName.RemoveSpecialCharacters();
+                        var filterControl = new RockTextBox()
+                        {
+                            Label = splitCaseName,
+                            ID = id
+                        };
+
+                        GridFilterColumnLookup.Add( filterControl, dataTableColumn.ColumnName );
+
+                        GridFilter.Controls.Add( filterControl );
+                        var key = filterControl.ID;
+                        var value = GridFilter.GetUserPreference( key );
+
+                        if ( value != null )
+                        {
+                            filterControl.Text = value;
+                        }
+                    }
+                }
+
+                bf.DataField = dataTableColumn.ColumnName;
+                bf.SortExpression = dataTableColumn.ColumnName;
+                bf.HeaderText = splitCaseName;
+                grid.Columns.Add( bf );
+            }
+        }
+
+        /// <summary>
+        /// Gets the sorted view.
+        /// </summary>
+        /// <param name="dataTable">The data table.</param>
+        /// <returns></returns>
+        private void SortTable( Grid grid, DataTable dataTable )
+        {
+            System.Data.DataView dataView = dataTable.DefaultView;
+
+            SortProperty sortProperty = grid.SortProperty;
+            if ( sortProperty != null )
+            {
+                dataView.Sort = string.Format( "{0} {1}", sortProperty.Property, sortProperty.DirectionString );
+            }
+        }
+
+        /// <summary>
+        /// Gets the sorted view.
+        /// </summary>
+        /// <param name="dataTable">The data table.</param>
+        /// <returns></returns>
+        private void FilterTable( Grid grid, DataTable dataTable )
+        {
+            var showGridFilterControls = GetAttributeValue( AttributeKey.ShowGridFilter ).AsBoolean();
+            System.Data.DataView dataView = dataTable.DefaultView;
+
+            if ( !showGridFilterControls )
+            {
+                dataView.RowFilter = null;
+                return;
+            }
+
+            var query = new List<string>();
+
+            foreach ( var control in GridFilter.Controls.OfType<Control>() )
+            {
+                if ( control is DateRangePicker )
+                {
+                    var dateRangePicker = control as DateRangePicker;
+                    var minValue = dateRangePicker.LowerValue;
+                    var maxValue = dateRangePicker.UpperValue;
+
+                    var colName = GridFilterColumnLookup[control];
+
+                    if ( minValue.HasValue )
+                    {
+                        query.Add( string.Format( "[{0}] >= #{1}#", colName, minValue.Value ) );
+                    }
+
+                    if ( maxValue.HasValue )
+                    {
+                        query.Add( string.Format( "[{0}] < #{1}#", colName, maxValue.Value.AddDays( 1 ) ) );
+                    }
+                }
+                else if ( control is RockDropDownList )
+                {
+                    var dropDownList = control as RockDropDownList;
+                    var doFilter = !string.IsNullOrWhiteSpace( dropDownList.SelectedValue );
+
+                    if ( doFilter )
+                    {
+                        var value = dropDownList.SelectedValue == true.ToYesNo() ? "1" : "0";
+                        var colName = GridFilterColumnLookup[control];
+                        query.Add( string.Format( "[{0}] = {1}", colName, value ) );
+                    }
+                }
+                else if ( control is RockTextBox )
+                {
+                    var textBox = control as RockTextBox;
+                    var value = textBox.Text;
+                    var colName = GridFilterColumnLookup[control];
+                    var colIndex = dataView.Table.Columns.IndexOf( colName );
+
+                    if ( colIndex != -1 && !string.IsNullOrWhiteSpace( value ) )
+                    {
+                        var col = dataView.Table.Columns[colIndex];
+
+                        if ( col.DataType.Name == "String" )
+                        {
+                            query.Add( string.Format( "[{0}] LIKE '%{1}%'", colName, value.Replace( "'", "''" ) ) );
+                        }
+                        else if ( col.DataType.Name.StartsWith( "Int" ) )
+                        {
+                            query.Add( string.Format( "[{0}] = {1}", colName, value ) );
+                        }
+                    }
+                }
+            }
+
+            dataView.RowFilter = string.Join( " AND ", query );
+        }
+
+        /// <summary>
+        /// Converts bool to string.
+        /// </summary>
+        /// <param name="b">The b.</param>
+        /// <returns></returns>
+        private string BoolToString( bool? b )
+        {
+            if ( b.HasValue )
+            {
+                return b.Value.ToYesNo();
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Converts string to bool
+        /// </summary>
+        /// <param name="s">The s.</param>
+        /// <returns></returns>
+        private bool? StringToBool( string s )
+        {
+            if ( s == BoolToString( true ) )
+            {
+                return true;
+            }
+
+            if ( s == BoolToString( false ) )
+            {
+                return false;
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        /// <summary>
+        ///
+        /// </summary>
+        private class DataRowDrop : DotLiquid.Drop
+        {
+            private readonly DataRow _dataRow;
+
+            public DataRowDrop( DataRow dataRow )
+            {
+                _dataRow = dataRow;
+            }
+
+            public override object BeforeMethod( string method )
+            {
+                if ( _dataRow.Table.Columns.Contains( method ) )
+                {
+                    return _dataRow[method];
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/Reporting/DynamicDataLava.ascx.cs
+++ b/Reporting/DynamicDataLava.ascx.cs
@@ -535,7 +535,7 @@ namespace RockWeb.Plugins.rocks_kfs.Reporting
                 {
                     var mergeFields = GetDynamicDataMergeFields();
 
-                    // NOTE: there is already a PageParameters merge field from GetDynamicDataMergeFields, but for backwords compatibility, also add each of the PageParameters as plain merge fields
+                    // NOTE: there is already a PageParameters merge field from GetDynamicDataMergeFields, but for backwards compatibility, also add each of the PageParameters as plain merge fields
                     foreach ( var pageParam in PageParameters() )
                     {
                         mergeFields.AddOrReplace( pageParam.Key, pageParam.Value );
@@ -546,7 +546,7 @@ namespace RockWeb.Plugins.rocks_kfs.Reporting
                     {
                         foreach ( var param in parameters )
                         {
-                            query.Replace( string.Format( "@{0}", param.Key ), ( string ) param.Value );
+                            query = query.Replace( string.Format( "@{0}", param.Key ), ( string ) param.Value );
                         }
                     }
                     query = query.ResolveMergeFields( mergeFields, enabledLavaCommands );
@@ -609,7 +609,6 @@ namespace RockWeb.Plugins.rocks_kfs.Reporting
             if ( list.Count == 0 )
                 return result;
 
-            var columnNames = list.SelectMany( dict => dict.Keys ).Distinct();
             var columnNameAndValues = list.DistinctBy( dict => dict.Keys );
             foreach ( var cn in columnNameAndValues )
             {
@@ -648,16 +647,16 @@ namespace RockWeb.Plugins.rocks_kfs.Reporting
             return result;
         }
 
-        private void GenerateDictionary( System.Dynamic.ExpandoObject output, Dictionary<string, object> dict, string parent )
+        private void GenerateDictionary( dynamic output, Dictionary<string, object> dict, string parent )
         {
             foreach ( var v in output )
             {
                 string key = parent + v.Key;
                 object o = v.Value;
 
-                if ( o != null && o.GetType() == typeof( System.Dynamic.ExpandoObject ) )
+                if ( o != null && o.GetType() == typeof( ExpandoObject ) )
                 {
-                    GenerateDictionary( ( System.Dynamic.ExpandoObject ) o, dict, key + "." );
+                    GenerateDictionary( ( dynamic ) o, dict, key + "." );
                 }
                 else if ( o != null && o.GetType().Name == typeof( List<object> ).Name )
                 {
@@ -665,7 +664,7 @@ namespace RockWeb.Plugins.rocks_kfs.Reporting
                     var listO = ( List<object> ) o;
                     foreach ( var l in listO )
                     {
-                        GenerateDictionary( ( ExpandoObject ) l, dict, string.Format( "{0}.{1}.", key, i ) );
+                        GenerateDictionary( ( dynamic ) l, dict, string.Format( "{0}.{1}.", key, i ) );
                         i++;
                     }
                 }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

This block gives you the ability to output lava into a Rock Grid will all its capabilities (format, filter, grid actions, etc.) You can use the standard ToJSON lava filter or create your own JSON object array.

**New Settings:**

- Show Lava Output for Debug Purposes

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Gives you the ability to output lava into a Rock Grid with all its capabilities (format, filter, grid actions, etc.)

---------

### Requested By

##### Who reported, requested, or paid for the change?

LGO

---------

### Screenshots

##### Does this update or add options to the block UI?

![DynamicDataLavaBlock](https://user-images.githubusercontent.com/2990519/174689116-052d6697-2945-4c8c-9787-2b7f17dee648.png)

![image](https://user-images.githubusercontent.com/2990519/174688312-fc1938da-8c84-475b-8188-48238dc5903a.png)

![image](https://user-images.githubusercontent.com/2990519/174689286-4beff886-3316-4b41-8d53-1705bdf3b6f0.png)

---------

### Change Log

##### What files does it affect?

- Reporting/DynamicDataLava.ascx
- Reporting/DynamicDataLava.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No