### PR TITLE
Pager Entry Groups Setting

### DIFF
--- a/CheckIn/PagerEntry.ascx.cs
+++ b/CheckIn/PagerEntry.ascx.cs
@@ -74,7 +74,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
         ListSource = "SELECT g.Guid Value, g.Name as Text FROM [Group] g  JOIN GroupType gt ON g.GroupTypeId = gt.Id LEFT JOIN GroupType igt ON igt.Id = gt.InheritedGroupTypeId LEFT JOIN GroupType igt2 ON igt2.Id = igt.InheritedGroupTypeId WHERE gt.Id = 15 OR igt.Id = 15 OR igt2.Id = 15",
         Description = "Select the check-in group(s) to utilize this pager entry capability. This capability will be displayed for all groups by default.",
         Category = "Options",
-        Order = 9 )]
+        Order = 10 )]
 
     public partial class PagerEntry : CheckInBlockMultiPerson
     {

--- a/CheckIn/PagerEntry.ascx.cs
+++ b/CheckIn/PagerEntry.ascx.cs
@@ -69,6 +69,13 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
         Category = "Options",
         Order = 9 )]
 
+    [CustomCheckboxListField( "Groups",
+        Key = AttributeKey.Groups,
+        ListSource = "SELECT g.Guid Value, g.Name as Text FROM [Group] g  JOIN GroupType gt ON g.GroupTypeId = gt.Id LEFT JOIN GroupType igt ON igt.Id = gt.InheritedGroupTypeId LEFT JOIN GroupType igt2 ON igt2.Id = igt.InheritedGroupTypeId WHERE gt.Id = 15 OR igt.Id = 15 OR igt2.Id = 15",
+        Description = "Select the check-in group(s) to utilize this pager entry capability. This capability will be displayed for all groups by default.",
+        Category = "Options",
+        Order = 9 )]
+
     public partial class PagerEntry : CheckInBlockMultiPerson
     {
         private new static class AttributeKey
@@ -78,6 +85,7 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
             public const string DisplayKeypad = "DisplayKeypad";
             public const string PagerAttribute = "PagerAttribute";
             public const string CheckinType = "CheckinType";
+            public const string Groups = "Groups";
             public const string MultiPersonFirstPage = CheckInBlockMultiPerson.AttributeKey.MultiPersonFirstPage;
             public const string MultiPersonDonePage = CheckInBlockMultiPerson.AttributeKey.MultiPersonDonePage;
         }
@@ -119,6 +127,35 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
                     }
                 }
 
+                var groupsSetting = GetAttributeValues( AttributeKey.Groups ).AsGuidList();
+                if ( groupsSetting.Any() && CurrentCheckInState.CheckIn.Families.Any( f => f.Selected ) )
+                {
+                    var family = CurrentCheckInState.CheckIn.Families.FirstOrDefault( f => f.Selected );
+                    if ( family != null )
+                    {
+                        var people = family.People.Where( p => p.Selected );
+                        var redirectToNextPage = true;
+                        foreach ( var person in people )
+                        {
+                            var groupTypes = person.GroupTypes.Where( gt => gt.Selected );
+                            foreach ( var groupType in groupTypes )
+                            {
+                                var groups = groupType.Groups.Where( g => g.Selected );
+                                foreach ( var group in groups )
+                                {
+                                    if ( groupsSetting.Contains( group.Group.Guid ) )
+                                    {
+                                        redirectToNextPage = false;
+                                    }
+                                }
+                            }
+                        }
+                        if ( redirectToNextPage )
+                        {
+                            GoToNextPage();
+                        }
+                    }
+                }
 
                 lTitle.Text = GetTitleText();
                 lbSubmit.Text = "Check In";


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Add "Groups" setting to the Pager Entry block to restrict pager number entry displaying for only certain groups.

**New Settings:**

*Groups*, Select the check-in group(s) to utilize this pager entry capability. This capability will be displayed for all groups by default.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Add "Groups" setting to the Pager Entry block to restrict pager number entry displaying for only certain groups.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/175076280-0fa283ea-eef0-47d6-987b-d4e23bbd8b49.png)

---------

### Change Log

##### What files does it affect?

CheckIn/PagerEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, but a migration was added for proper installation. [RockAssemblies#](https://github.com/KingdomFirst/RockAssemblies/pull/80) 
