### PR TITLE
Person Contact Notes Mobile View

### DIFF
--- a/Crm/PersonContactNotes.ascx
+++ b/Crm/PersonContactNotes.ascx
@@ -2,7 +2,7 @@
 
 <asp:UpdatePanel ID="upPersonContactNotes" runat="server">
     <ContentTemplate>
-        <div class="row row-eq-height">
+        <div class="row">
             <div class="col-md-4">
                 <asp:Panel ID="pnlSelectPerson" CssClass="panel panel-block" runat="server">
                     <div class="panel-heading">


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

I am not sure why I was using `row-eq-height` class in this block, but it was unnecessary from what I could tell, so I removed it. Much better mobile view.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added a fix for mobile view of Person Contact Notes.

---------

### Requested By

##### Who reported, requested, or paid for the change?

CBCNeenah

---------

### Screenshots

##### Does this update or add options to the block UI?

Before:   
![image](https://user-images.githubusercontent.com/2990519/177650868-24ca9b36-c8f8-4afd-b3a3-886811ba1e4b.png)

After:   
![image](https://user-images.githubusercontent.com/2990519/177651097-b45df38d-2c3b-4c44-9fb0-f1cd9d36dce0.png)

---------

### Change Log

##### What files does it affect?

Crm/PersonContactNotes.ascx

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No