### PR TITLE
Check-in Pager Entry Update

### DIFF
--- a/CheckIn/PagerEntry.ascx.cs
+++ b/CheckIn/PagerEntry.ascx.cs
@@ -137,10 +137,10 @@ namespace RockWeb.Plugins.rocks_kfs.CheckIn
                         var redirectToNextPage = true;
                         foreach ( var person in people )
                         {
-                            var groupTypes = person.GroupTypes.Where( gt => gt.Selected );
+                            var groupTypes = person.GroupTypes;
                             foreach ( var groupType in groupTypes )
                             {
-                                var groups = groupType.Groups.Where( g => g.Selected );
+                                var groups = groupType.Groups;
                                 foreach ( var group in groups )
                                 {
                                     if ( groupsSetting.Contains( group.Group.Guid ) )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Update to check-in pager entry. If you don't actually select a group during the check-in process, i.e. it gets auto selected, it will not be in the "Selected" result set, fix it so that is not required.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fix Pager entry when groups are auto selected, still filter.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

CheckIn/PagerEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
