### PR TITLE
Steps to Care Future Needs

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -184,6 +184,16 @@
                         effect: "fadeIn"
                     });
 
+                    $('#<%=drpDate.ClientID%>').datepicker({
+                        format: 'mm/dd/yyyy',
+                        todayHighlight: true,
+                        assumeNearbyYear: 10,
+                        autoclose: true,
+                        endDate: '+0d',
+                        inputs: $('#<%=drpDate.ClientID%> .form-control'),
+                        zIndexOffset: 1050
+                    });
+
                     // person-link-popover
                     $('.js-person-popover').popover({
                         placement: 'right',

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -111,7 +111,7 @@
                             <Rock:RockDropDownList ID="ddlSubmitter" runat="server" Label="Submitted By" EnhanceForLongLists="true" />
                             <Rock:CampusPicker ID="cpCampus" runat="server" Label="Campus" />
                             <Rock:RockCheckBox ID="cbAssignedToMe" runat="server" Label="Assigned to Me" />
-                            <Rock:RockCheckBox ID="cbIncludeFutureNeeds" runat="server" Label="Include Future Needs" />
+                            <Rock:RockCheckBox ID="cbIncludeFutureNeeds" runat="server" Label="Include Scheduled Needs" />
                             <asp:PlaceHolder ID="phAttributeFilters" runat="server" />
                         </Rock:GridFilter>
                         <Rock:Grid ID="gList" runat="server" DisplayType="Full" AllowSorting="true" ExportSource="DataSource">

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -8,7 +8,9 @@
         display: inline;
     }
 
-    .grid-table>tbody>tr>td:empty, .grid-table>tbody>tr>th:empty, .grid-table>thead>tr>td:empty, .grid-table>thead>tr>th:empty { padding: 0; }
+    .grid-table > tbody > tr > td:empty, .grid-table > tbody > tr > th:empty, .grid-table > thead > tr > td:empty, .grid-table > thead > tr > th:empty {
+        padding: 0;
+    }
 
     .table-striped > tbody > tr.assigned:nth-of-type(odd) {
         background-color: oldlace;
@@ -109,6 +111,7 @@
                             <Rock:RockDropDownList ID="ddlSubmitter" runat="server" Label="Submitted By" EnhanceForLongLists="true" />
                             <Rock:CampusPicker ID="cpCampus" runat="server" Label="Campus" />
                             <Rock:RockCheckBox ID="cbAssignedToMe" runat="server" Label="Assigned to Me" />
+                            <Rock:RockCheckBox ID="cbIncludeFutureNeeds" runat="server" Label="Include Future Needs" />
                             <asp:PlaceHolder ID="phAttributeFilters" runat="server" />
                         </Rock:GridFilter>
                         <Rock:Grid ID="gList" runat="server" DisplayType="Full" AllowSorting="true" ExportSource="DataSource">

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -725,7 +725,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     return;
 
                 case UserPreferenceKey.AssignedToMe:
-                case UserPreferenceKey.IncludeFutureNeeds:
+                case UserPreferenceKey.IncludeScheduledNeeds:
                     if ( !e.Value.AsBoolean() )
                     {
                         e.Value = string.Empty;
@@ -1722,7 +1722,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 dvpStatus.SetValue( statusValue );
 
                 cbAssignedToMe.Checked = rFilter.GetUserPreference( UserPreferenceKey.AssignedToMe ).AsBoolean();
-                cbIncludeFutureNeeds.Checked = rFilter.GetUserPreference( UserPreferenceKey.IncludeFutureNeeds ).AsBoolean();
+                cbIncludeFutureNeeds.Checked = rFilter.GetUserPreference( UserPreferenceKey.IncludeScheduledNeeds ).AsBoolean();
                 var followUpAssignedToMe = rFollowUpFilter.GetUserPreference( UserPreferenceKey.AssignedToMeFollowUp );
                 if ( !string.IsNullOrWhiteSpace( followUpAssignedToMe ) )
                 {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -210,6 +210,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Order = 19,
         Key = AttributeKey.NoteViewLavaTemplate )]
 
+    [IntegerField( "Threshold of Days For Future Need",
+        Description = "The number of days the need has to be within before displaying on the dashboard.",
+        IsRequired = true,
+        DefaultIntegerValue = 3,
+        Key = AttributeKey.FutureThresholdDays )]
+
     [SecurityAction(
         SecurityActionKey.CareWorkers,
         "The roles and/or users that have access to view 'Care Worker Only' needs." )]
@@ -254,6 +260,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string WorkflowEnable = "WorkflowEnable";
             public const string CompleteChildNeeds = "CompleteChildNeeds";
             public const string TargetModeIncludeFamilyMembers = "TargetModeIncludeFamilyMembers";
+            public const string FutureThresholdDays = "FutureThresholdDays";
         }
 
         /// <summary>
@@ -1074,7 +1081,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         }
                         if ( careNeed.PersonAlias != null )
                         {
-                            lName.Text = string.Format( "{3} {4} <a href=\"{0}\">{1}</a> {2}", ResolveUrl( string.Format( "~/Person/{0}", careNeed.PersonAlias.PersonId ) ), careNeed.PersonAlias.Person.FullName ?? string.Empty, careNeedFlagStr, childNeedStr, parentNeedStr );
+                            lName.Text = string.Format( "{3} {4} <a href=\"{0}\" class=\"js-person-popover\" personid=\"{5}\">{1}</a> {2}", ResolveUrl( string.Format( "~/Person/{0}", careNeed.PersonAlias.PersonId ) ), careNeed.PersonAlias.Person.FullName ?? string.Empty, careNeedFlagStr, childNeedStr, parentNeedStr, careNeed.PersonAlias.PersonId );
                         }
                     }
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -277,6 +277,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string Status = "Status";
             public const string Campus = "Campus";
             public const string AssignedToMe = "Assigned to Me";
+            public const string IncludeFutureNeeds = "Include Future Needs";
             public const string StartDateFollowUp = "FollowUp Start Date";
             public const string EndDateFollowUp = "FollowUp End Date";
             public const string FirstNameFollowUp = "FollowUp First Name";
@@ -578,6 +579,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             rFilter.SaveUserPreference( UserPreferenceKey.Status, "Status", dvpStatus.SelectedItem.Value );
             rFilter.SaveUserPreference( UserPreferenceKey.Campus, "Campus", cpCampus.SelectedCampusId.ToString() );
             rFilter.SaveUserPreference( UserPreferenceKey.AssignedToMe, "Assigned to Me", cbAssignedToMe.Checked.ToString() );
+            rFilter.SaveUserPreference( UserPreferenceKey.IncludeFutureNeeds, "Include Future Needs", cbIncludeFutureNeeds.Checked.ToString() );
 
             if ( AvailableAttributes != null )
             {
@@ -723,6 +725,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     return;
 
                 case UserPreferenceKey.AssignedToMe:
+                case UserPreferenceKey.IncludeFutureNeeds:
                     if ( !e.Value.AsBoolean() )
                     {
                         e.Value = string.Empty;
@@ -1719,6 +1722,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 dvpStatus.SetValue( statusValue );
 
                 cbAssignedToMe.Checked = rFilter.GetUserPreference( UserPreferenceKey.AssignedToMe ).AsBoolean();
+                cbIncludeFutureNeeds.Checked = rFilter.GetUserPreference( UserPreferenceKey.IncludeFutureNeeds ).AsBoolean();
                 var followUpAssignedToMe = rFollowUpFilter.GetUserPreference( UserPreferenceKey.AssignedToMeFollowUp );
                 if ( !string.IsNullOrWhiteSpace( followUpAssignedToMe ) )
                 {
@@ -1959,6 +1963,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = PermissionFilterQuery( qry );
             }
 
+            var futureDate = DateTime.Now.AddDays( GetAttributeValue( AttributeKey.FutureThresholdDays ).AsInteger() );
+
             // Filter by Start Date
             DateTime? startDate = drpDate.LowerValue;
             if ( startDate != null )
@@ -1971,6 +1977,11 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             if ( endDate != null )
             {
                 qry = qry.Where( b => b.DateEntered <= endDate );
+            }
+
+            if ( !cbIncludeFutureNeeds.Checked )
+            {
+                qry = qry.Where( b => b.DateEntered <= futureDate );
             }
 
             // Filter by Campus

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -210,8 +210,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Order = 19,
         Key = AttributeKey.NoteViewLavaTemplate )]
 
-    [IntegerField( "Threshold of Days For Future Need",
-        Description = "The number of days the need has to be within before displaying on the dashboard.",
+    [IntegerField( "Threshold of Days for Scheduled Needs",
+        Description = "The number of days from today to display scheduled needs on the dashboard.",
         IsRequired = true,
         DefaultIntegerValue = 3,
         Key = AttributeKey.FutureThresholdDays )]
@@ -277,7 +277,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string Status = "Status";
             public const string Campus = "Campus";
             public const string AssignedToMe = "Assigned to Me";
-            public const string IncludeFutureNeeds = "Include Future Needs";
+            public const string IncludeScheduledNeeds = "Include Scheduled Needs";
             public const string StartDateFollowUp = "FollowUp Start Date";
             public const string EndDateFollowUp = "FollowUp End Date";
             public const string FirstNameFollowUp = "FollowUp First Name";
@@ -579,7 +579,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             rFilter.SaveUserPreference( UserPreferenceKey.Status, "Status", dvpStatus.SelectedItem.Value );
             rFilter.SaveUserPreference( UserPreferenceKey.Campus, "Campus", cpCampus.SelectedCampusId.ToString() );
             rFilter.SaveUserPreference( UserPreferenceKey.AssignedToMe, "Assigned to Me", cbAssignedToMe.Checked.ToString() );
-            rFilter.SaveUserPreference( UserPreferenceKey.IncludeFutureNeeds, "Include Future Needs", cbIncludeFutureNeeds.Checked.ToString() );
+            rFilter.SaveUserPreference( UserPreferenceKey.IncludeScheduledNeeds, "Include Scheduled Needs", cbIncludeFutureNeeds.Checked.ToString() );
 
             if ( AvailableAttributes != null )
             {

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -19,21 +19,17 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.Entity;
 using System.Linq;
-using System.Text;
-using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using NuGet;
 using Rock;
 using Rock.Attribute;
-using Rock.Communication;
 using Rock.Data;
-using Rock.Logging;
 using Rock.Model;
 using Rock.Security;
-using Rock.Web;
 using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
+using rocks.kfs.StepsToCare;
 using rocks.kfs.StepsToCare.Model;
 
 namespace RockWeb.Plugins.rocks_kfs.StepsToCare
@@ -44,7 +40,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
     [Category( "KFS > Steps To Care" )]
     [Description( "Care entry block for KFS Steps to Care package. Used for adding and editing care needs " )]
 
-    #endregion
+    #endregion Block Attributes
 
     #region Block Settings
 
@@ -97,14 +93,18 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.AdultFamilyWorkers,
         Category = AttributeCategory.FamilyNeeds )]
 
+    [IntegerField( "Threshold of Days before Assignment",
+        Description = "The number of days you can schedule a need in the future before a need will be assigned to workers.",
+        IsRequired = true,
+        DefaultIntegerValue = 3,
+        Key = AttributeKey.FutureThresholdDays )]
+
     [SecurityAction(
         SecurityActionKey.UpdateStatus,
         "The roles and/or users that have access to update the status of Care Needs." )]
-    #endregion
-
+    #endregion Block Settings
     public partial class CareEntry : Rock.Web.UI.RockBlock
     {
-
         /// <summary>
         /// Attribute Keys
         /// </summary>
@@ -119,7 +119,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string EnableFamilyNeeds = "EnableFamilyNeeds";
             public const string AdultFamilyWorkers = "AdultFamilyWorkers";
             public const string LoadBalanceWorkersType = "LoadBalanceWorkersType";
+            public const string FutureThresholdDays = "FutureThresholdDays";
         }
+
         private static class PageParameterKey
         {
             public const string PersonId = "PersonId";
@@ -139,12 +141,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         private static class SecurityActionKey
         {
             public const string UpdateStatus = "UpdateStatus";
-
         }
 
         private bool _allowNewPerson = false;
 
         #region Properties
+
         /// <summary>
         /// Gets or sets the Assigned Persons to the list.
         /// </summary>
@@ -170,7 +172,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 Session["AssignedPersons"] = value;
             }
         }
-        #endregion
+
+        #endregion Properties
 
         #region Base Control Methods
 
@@ -223,7 +226,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             confirmExit.Enabled = true;
         }
 
-        #endregion
+        #endregion Base Control Methods
 
         #region Events
 
@@ -349,7 +352,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                             var loc = lapAddress.Location;
                                             familyAddress.Location = new LocationService( rockContext ).Get(
                                                 loc.Street1, loc.Street2, loc.City, loc.State, loc.PostalCode, loc.Country, familyGroup, true );
-
                                         }
                                     }
                                 }
@@ -474,12 +476,24 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         careNeed.SaveAttributeValues( rockContext );
                     } );
 
-                    if ( isNew )
+                    var autoAssignWorker = GetAttributeValue( AttributeKey.AutoAssignWorker ).AsBoolean();
+                    var autoAssignWorkerGeofence = GetAttributeValue( AttributeKey.AutoAssignWorkerGeofence ).AsBoolean();
+                    var loadBalanceType = GetAttributeValue( AttributeKey.LoadBalanceWorkersType );
+                    var enableLogging = GetAttributeValue( AttributeKey.VerboseLogging ).AsBoolean();
+                    var leaderRoleGuid = GetAttributeValue( AttributeKey.GroupTypeAndRole ).AsGuidOrNull() ?? Guid.Empty;
+                    var futureThresholdDays = GetAttributeValue( AttributeKey.FutureThresholdDays ).AsDouble();
+
+                    double dateDifference = 0;
+                    if ( careNeed.DateEntered.HasValue )
                     {
-                        AutoAssignWorkers( careNeed );
+                        dateDifference = ( careNeed.DateEntered.Value - DateTime.Now ).TotalDays;
+                    }
+                    if ( isNew && dateDifference <= futureThresholdDays )
+                    {
+                        CareUtilities.AutoAssignWorkers( careNeed, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                     }
 
-                    if ( childNeedsCreated && careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
+                    if ( childNeedsCreated && careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() && dateDifference <= futureThresholdDays )
                     {
                         var familyGroupType = GroupTypeCache.GetFamilyGroupType();
                         var adultRoleId = familyGroupType.Roles.FirstOrDefault( a => a.Guid == Rock.SystemGuid.GroupRole.GROUPROLE_FAMILY_MEMBER_ADULT.AsGuid() ).Id;
@@ -487,114 +501,22 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         {
                             if ( need.PersonAlias != null && need.PersonAlias.Person.GetFamilyRole().Id != adultRoleId )
                             {
-                                AutoAssignWorkers( need, true, true );
+                                CareUtilities.AutoAssignWorkers( need, true, true, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                             }
                             else
                             {
                                 var adultFamilyWorkers = GetAttributeValue( AttributeKey.AdultFamilyWorkers );
-                                AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only" );
+                                CareUtilities.AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only", autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                             }
                         }
                     }
 
-                    // if a NewAssignmentNotificationEmailTemplate is configured, send an email
-                    var assignmentEmailTemplateGuid = GetAttributeValue( AttributeKey.NewAssignmentNotification ).AsGuidOrNull();
-
-                    var assignedPersons = careNeed.AssignedPersons;
-                    if ( newlyAssignedPersons.Any() )
+                    if ( dateDifference <= futureThresholdDays )
                     {
-                        assignedPersons = newlyAssignedPersons;
-                    }
-                    else
-                    {
-                        // Reload Care Need after save changes
-                        careNeed = new CareNeedService( new RockContext() ).Get( careNeed.Id );
-                        assignedPersons = careNeed.AssignedPersons;
-                        if ( careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() )
-                        {
-                            foreach ( var need in careNeed.ChildNeeds )
-                            {
-                                assignedPersons.AddRange( need.AssignedPersons );
-                            }
-                        }
-                    }
+                        // if a NewAssignmentNotificationEmailTemplate is configured, send an email
+                        var assignmentEmailTemplateGuid = GetAttributeValue( AttributeKey.NewAssignmentNotification ).AsGuidOrNull();
 
-                    if ( assignedPersons != null && assignedPersons.Any() && assignmentEmailTemplateGuid.HasValue && ( isNew || newlyAssignedPersons.Any() ) )
-                    {
-                        var errors = new List<string>();
-                        var errorsSms = new List<string>();
-                        Dictionary<string, object> linkedPages = new Dictionary<string, object>();
-                        linkedPages.Add( "CareDetail", CurrentPageReference.BuildUrl() );
-                        linkedPages.Add( "CareDashboard", GetParentPage().BuildUrl() );
-
-                        var systemCommunication = new SystemCommunicationService( rockContext ).Get( assignmentEmailTemplateGuid.Value );
-                        var emailMessage = new RockEmailMessage( systemCommunication );
-                        var smsMessage = new RockSMSMessage( systemCommunication );
-                        emailMessage.AppRoot = smsMessage.AppRoot = ResolveRockUrl( "~/" );
-                        emailMessage.ThemeRoot = smsMessage.ThemeRoot = ResolveRockUrl( "~~/" );
-                        foreach ( var assignee in assignedPersons )
-                        {
-                            assignee.PersonAlias.Person.LoadAttributes();
-                            var smsNumber = assignee.PersonAlias.Person.PhoneNumbers.GetFirstSmsNumber();
-                            if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) && smsNumber.IsNullOrWhiteSpace() )
-                            {
-                                continue;
-                            }
-
-                            var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
-                            mergeFields.Add( "CareNeed", careNeed );
-                            mergeFields.Add( "LinkedPages", linkedPages );
-                            mergeFields.Add( "AssignedPerson", assignee );
-                            mergeFields.Add( "Person", assignee.PersonAlias.Person );
-
-                            var notificationType = assignee.PersonAlias.Person.GetAttributeValue( rocks.kfs.StepsToCare.SystemGuid.PersonAttribute.NOTIFICATION.AsGuid() );
-
-                            if ( notificationType == null || notificationType == "Email" || notificationType == "Both" )
-                            {
-                                if ( !assignee.PersonAlias.Person.CanReceiveEmail( false ) )
-                                {
-                                    var emailWarningMessage = string.Format( "{0} does not have a valid email address.", assignee.PersonAlias.Person.FullName );
-                                    RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", emailWarningMessage );
-                                    errors.Add( emailWarningMessage );
-                                }
-                                else
-                                {
-                                    emailMessage.AddRecipient( new RockEmailMessageRecipient( assignee.PersonAlias.Person, mergeFields ) );
-                                }
-                            }
-
-                            if ( notificationType == "SMS" || notificationType == "Both" )
-                            {
-                                if ( string.IsNullOrWhiteSpace( smsNumber ) )
-                                {
-                                    var smsWarningMessage = string.Format( "No SMS number could be found for {0}.", assignee.PersonAlias.Person.FullName );
-                                    RockLogger.Log.Warning( "RockWeb.Plugins.rocks_kfs.StepsToCare.CareEntry", smsWarningMessage );
-                                    errorsSms.Add( smsWarningMessage );
-                                }
-
-                                smsMessage.AddRecipient( new RockSMSMessageRecipient( assignee.PersonAlias.Person, smsNumber, mergeFields ) );
-                            }
-                        }
-                        if ( emailMessage.GetRecipients().Count > 0 )
-                        {
-                            emailMessage.Send( out errors );
-                        }
-                        if ( smsMessage.GetRecipients().Count > 0 )
-                        {
-                            smsMessage.Send( out errorsSms );
-                        }
-
-                        if ( errors.Any() || errorsSms.Any() )
-                        {
-                            StringBuilder sb = new StringBuilder();
-                            sb.Append( string.Format( "{0} Errors Sending Care Assignment Notification: ", errors.Count + errorsSms.Count ) );
-                            errors.ForEach( es => { sb.AppendLine(); sb.Append( es ); } );
-                            errorsSms.ForEach( es => { sb.AppendLine(); sb.Append( es ); } );
-                            string errorStr = sb.ToString();
-                            var exception = new Exception( errorStr );
-                            HttpContext context = HttpContext.Current;
-                            ExceptionLogService.LogException( exception, context );
-                        }
+                        CareUtilities.SendWorkerNotification( rockContext, careNeed, isNew, newlyAssignedPersons, assignmentEmailTemplateGuid, RockPage );
                     }
 
                     // redirect back to parent
@@ -737,7 +659,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             }
 
             BindAssignedPersonsGrid();
-
         }
 
         /// <summary>
@@ -811,7 +732,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
             bddlAddWorker.ClearSelection();
         }
-        #endregion
+
+        #endregion Events
 
         #region Methods
 
@@ -955,7 +877,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 pwAssigned.Visible = false;
             }
 
-
             careNeed.LoadAttributes();
             Helper.AddEditControls( careNeed, phAttributes, true, BlockValidationGroup, 2 );
 
@@ -994,466 +915,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             ppSubmitter.Visible = true;
         }
 
-        private void AutoAssignWorkers( CareNeed careNeed, bool roundRobinOnly = false, bool childAssignment = false )
-        {
-            var rockContext = new RockContext();
-
-            var autoAssignWorker = GetAttributeValue( AttributeKey.AutoAssignWorker ).AsBoolean();
-            var autoAssignWorkerGeofence = GetAttributeValue( AttributeKey.AutoAssignWorkerGeofence ).AsBoolean();
-            var loadBalanceType = GetAttributeValue( AttributeKey.LoadBalanceWorkersType );
-
-            var careNeedService = new CareNeedService( rockContext );
-            var careWorkerService = new CareWorkerService( rockContext );
-            var careAssigneeService = new AssignedPersonService( rockContext );
-
-            // reload careNeed to fully populate child properties
-            careNeed = careNeedService.Get( careNeed.Guid );
-
-            var careWorkers = careWorkerService.Queryable().AsNoTracking().Where( cw => cw.IsActive );
-
-            var addedWorkerAliasIds = new List<int?>();
-
-            var enableLogging = GetAttributeValue( AttributeKey.VerboseLogging ).AsBoolean();
-
-            // auto assign Deacon/Worker by Geofence
-            if ( autoAssignWorkerGeofence && !roundRobinOnly )
-            {
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, CareWorkers Count: {1}", careNeed.Guid, careWorkers.Count() ), "Geofence assignment start." );
-                }
-                var careWorkersWithFence = careWorkers.Where( cw => cw.GeoFenceId != null );
-                foreach ( var worker in careWorkersWithFence )
-                {
-                    var geofenceLocation = new LocationService( rockContext ).Get( worker.GeoFenceId.Value );
-                    if ( enableLogging )
-                    {
-                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceLocation: {1}", careNeed.Guid, geofenceLocation.Id ), "Care Workers with Fence" );
-                    }
-                    var homeLocation = careNeed.PersonAlias.Person.GetHomeLocation();
-                    if ( enableLogging )
-                    {
-                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceLocation: {1}, homeLocation: {2}", careNeed.Guid, geofenceLocation.Id, ( homeLocation != null ) ? homeLocation.Id.ToString() : "null" ), "Care Workers with Fence" );
-                    }
-                    if ( homeLocation != null && homeLocation.GeoPoint != null )
-                    {
-                        var geofenceIntersect = homeLocation.GeoPoint.Intersects( geofenceLocation.GeoFence );
-                        if ( enableLogging )
-                        {
-                            LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, geofenceIntersect: {1}, homeLocation: {2}", careNeed.Guid, geofenceIntersect, homeLocation.Id ), "geofenceIntersect" );
-                        }
-                        if ( geofenceIntersect )
-                        {
-                            var careAssignee = new AssignedPerson { Id = 0 };
-                            careAssignee.CareNeed = careNeed;
-                            careAssignee.PersonAliasId = worker.PersonAliasId;
-                            careAssignee.WorkerId = worker.Id;
-                            //careAssignee.FollowUpWorker = true;
-
-                            careAssigneeService.Add( careAssignee );
-                            addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
-                        }
-                    }
-                    else if ( homeLocation != null && homeLocation.GeoPoint == null )
-                    {
-                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Id: {0}, homeLocation: {1}", careNeed.Id, homeLocation.Id ), "Home Location does not have a valid GeoPoint. Please verify their address and manually assign their geo worker." );
-                    }
-                }
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkersWithFence Count: {1} addedWorkerAliasIds Count: {2}", careNeed.Guid, careWorkersWithFence.Count(), addedWorkerAliasIds.Count() ), "Geofence assignment end." );
-                }
-            }
-
-            //auto assign worker/pastor by load balance assignment
-            if ( autoAssignWorker )
-            {
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, CareWorkers Count: {1}", careNeed.Guid, careWorkers.Count() ), "Auto Assign Worker start." );
-                }
-                var careWorkersNoFence = careWorkers.Where( cw => cw.GeoFenceId == null );
-                var workerAssigned = false;
-                var closedId = DefinedValueCache.Get( rocks.kfs.StepsToCare.SystemGuid.DefinedValue.CARE_NEED_STATUS_CLOSED ).Id;
-
-                // Campus, Category, Ignore Age Range and Gender
-                var careWorkerCount1 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, true, true );
-
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkersNoFence Count: {1}, careWorkerCount1 Count: {2}", careNeed.Guid, careWorkersNoFence.Count(), careWorkerCount1.Count() ), "careWorkerCount1, Category AND Campus" );
-                }
-
-                // Category, Ignore Age Range and Gender
-                var careWorkerCount2 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, true, true );
-
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount2 Count: {1}", careNeed.Guid, careWorkerCount2.Count() ), "careWorkerCount2, Category NOT Campus" );
-                }
-
-                // Campus, Ignore Age Range and Gender
-                var careWorkerCount3 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, false, true );
-
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount3 Count: {1}", careNeed.Guid, careWorkerCount3.Count() ), "careWorkerCount3, Campus NOT Category" );
-                }
-
-                // None, doesn't include parameters for other values though.
-                var careWorkerCount4 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, false, true );
-
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCount4 Count: {1}", careNeed.Guid, careWorkerCount4.Count() ), "careWorkerCount4, NOT Campus or Category" );
-                }
-
-                IOrderedQueryable<WorkerResult> careWorkersCountChild1 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild2 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild3 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild4 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild5 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild6 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild7 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild8 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild9 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild10 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild11 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild12 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild13 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild14 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild15 = null;
-                IOrderedQueryable<WorkerResult> careWorkersCountChild16 = null;
-                if ( childAssignment )
-                {
-                    // AgeRange, Gender, Campus, Category
-                    careWorkersCountChild1 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, true );
-
-                    // AgeRange, Gender, Category
-                    careWorkersCountChild2 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, true );
-
-                    // AgeRange, Gender, Campus
-                    careWorkersCountChild3 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, true, false );
-
-                    // AgeRange, Campus, Category
-                    careWorkersCountChild4 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, true );
-
-                    // Gender, Campus, Category
-                    careWorkersCountChild5 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, true );
-
-                    // AgeRange, Gender
-                    careWorkersCountChild6 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, true, false, false );
-
-                    // AgeRange, Category
-                    careWorkersCountChild7 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, true );
-
-                    // AgeRange, Campus
-                    careWorkersCountChild8 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, true, false );
-
-                    // Gender, Category
-                    careWorkersCountChild9 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, true );
-
-                    // Gender, Campus
-                    careWorkersCountChild10 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, true, false );
-
-                    // Campus, Category
-                    careWorkersCountChild11 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, true );
-
-                    // AgeRange
-                    careWorkersCountChild12 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, true, false, false, false );
-
-                    // Gender 
-                    careWorkersCountChild13 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, true, false, false );
-
-                    // Category
-                    careWorkersCountChild14 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, true );
-
-                    // Campus
-                    careWorkersCountChild15 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, true, false );
-
-                    // None
-                    careWorkersCountChild16 = GenerateAgeQuery( careNeed, careWorkersNoFence, closedId, false, false, false, false );
-
-                }
-
-                var careWorkerCounts = careWorkerCount1;
-                if ( loadBalanceType == "Prioritize" )
-                {
-                    if ( childAssignment )
-                    {
-                        careWorkerCounts = careWorkersCountChild1
-                                            .Concat( careWorkersCountChild2 )
-                                            .Concat( careWorkersCountChild3 )
-                                            .Concat( careWorkersCountChild4 )
-                                            .Concat( careWorkersCountChild5 )
-                                            .Concat( careWorkersCountChild6 )
-                                            .Concat( careWorkersCountChild7 )
-                                            .Concat( careWorkersCountChild8 )
-                                            .Concat( careWorkersCountChild9 )
-                                            .Concat( careWorkersCountChild10 )
-                                            .Concat( careWorkersCountChild11 )
-                                            .Concat( careWorkersCountChild12 )
-                                            .Concat( careWorkersCountChild13 )
-                                            .Concat( careWorkersCountChild14 )
-                                            .Concat( careWorkersCountChild15 )
-                                            .Concat( careWorkersCountChild16 )
-                                            .OrderBy( ct => ct.Count )
-                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )         // AgeRange, Gender, Campus, Category
-                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )        // AgeRange, Gender, Category
-                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )        // AgeRange, Gender, Campus
-                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )        // AgeRange, Campus, Category
-                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && ct.HasCategory )        // Gender, Campus, Category
-                                            .ThenByDescending( ct => ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )       // AgeRange, Gender
-                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )       // AgeRange, Category
-                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )       // AgeRange, Campus
-                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && ct.HasCategory )       // Gender, Category
-                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && ct.HasCampus && !ct.HasCategory )       // Gender, Campus
-                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && ct.HasCategory )       // Campus, Category
-                                            .ThenByDescending( ct => ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // AgeRange
-                                            .ThenByDescending( ct => !ct.HasAgeRange && ct.HasGender && !ct.HasCampus && !ct.HasCategory )      // Gender
-                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && ct.HasCategory )      // Category
-                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && ct.HasCampus && !ct.HasCategory )      // Campus
-                                            .ThenByDescending( ct => !ct.HasAgeRange && !ct.HasGender && !ct.HasCampus && !ct.HasCategory );    // None
-                    }
-                    else
-                    {
-                        careWorkerCounts = careWorkerCount1
-                                        .Concat( careWorkerCount2 )
-                                        .Concat( careWorkerCount3 )
-                                        .Concat( careWorkerCount4 )
-                                        .OrderBy( ct => ct.Count )
-                                        .ThenByDescending( ct => ct.HasCategory && ct.HasCampus )
-                                        .ThenByDescending( ct => ct.HasCategory && !ct.HasCampus )
-                                        .ThenByDescending( ct => ct.HasCampus && !ct.HasCategory );
-                    }
-                }
-                else
-                {
-                    if ( childAssignment )
-                    {
-                        if ( careWorkersCountChild1.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild1;
-                        }
-                        else if ( careWorkersCountChild2.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild2;
-                        }
-                        else if ( careWorkersCountChild3.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild3;
-                        }
-                        else if ( careWorkersCountChild4.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild4;
-                        }
-                        else if ( careWorkersCountChild5.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild5;
-                        }
-                        else if ( careWorkersCountChild6.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild6;
-                        }
-                        else if ( careWorkersCountChild7.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild7;
-                        }
-                        else if ( careWorkersCountChild8.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild8;
-                        }
-                        else if ( careWorkersCountChild9.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild9;
-                        }
-                        else if ( careWorkersCountChild10.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild10;
-                        }
-                        else if ( careWorkersCountChild11.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild11;
-                        }
-                        else if ( careWorkersCountChild12.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild12;
-                        }
-                        else if ( careWorkersCountChild13.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild13;
-                        }
-                        else if ( careWorkersCountChild14.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild14;
-                        }
-                        else if ( careWorkersCountChild15.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild15;
-                        }
-                        else if ( careWorkersCountChild16.Any() )
-                        {
-                            careWorkerCounts = careWorkersCountChild16;
-                        }
-                    }
-                    else
-                    {
-                        if ( careWorkerCount1.Any() )
-                        {
-                            careWorkerCounts = careWorkerCount1;
-                        }
-                        else if ( careWorkerCount2.Any() )
-                        {
-                            careWorkerCounts = careWorkerCount2;
-                        }
-                        else if ( careWorkerCount3.Any() )
-                        {
-                            careWorkerCounts = careWorkerCount3;
-                        }
-                        else if ( careWorkerCount4.Any() )
-                        {
-                            careWorkerCounts = careWorkerCount4;
-                        }
-                    }
-                }
-
-                if ( enableLogging )
-                {
-                    LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, careWorkerCounts Count: {1}", careNeed.Guid, careWorkerCounts.Count() ), "Combined careWorkerCounts" );
-                }
-
-                foreach ( var workerCount in careWorkerCounts )
-                {
-                    var worker = workerCount.Worker;
-                    if ( !workerAssigned && !addedWorkerAliasIds.Contains( worker.PersonAliasId ) && worker.PersonAlias != null && careAssigneeService.GetByPersonAliasAndCareNeed( worker.PersonAlias.Id, careNeed.Id ) == null )
-                    {
-                        var careAssignee = new AssignedPerson { Id = 0 };
-                        careAssignee.CareNeed = careNeed;
-                        careAssignee.PersonAliasId = worker.PersonAliasId;
-                        careAssignee.WorkerId = worker.Id;
-                        careAssignee.FollowUpWorker = true;
-
-                        careAssigneeService.Add( careAssignee );
-                        addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
-
-                        workerAssigned = true;
-
-                        if ( enableLogging )
-                        {
-                            LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, Worker PersonAliasId: {1}, WorkerId: {2}", careNeed.Guid, worker.PersonAliasId, worker.Id ), "Worker Assigned" );
-                        }
-                    }
-                }
-            }
-
-            // auto assign Small Group Leader by Role
-            var leaderRoleGuid = GetAttributeValue( AttributeKey.GroupTypeAndRole ).AsGuidOrNull() ?? Guid.Empty;
-            var leaderRole = new GroupTypeRoleService( rockContext ).Get( leaderRoleGuid );
-            if ( enableLogging )
-            {
-                LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, Leader Role Guid: {1}, Leader Role: {2}", careNeed.Guid, leaderRoleGuid, leaderRole.Id ), "Get Leader Role" );
-            }
-
-            if ( leaderRole != null && !roundRobinOnly )
-            {
-                var groupMemberService = new GroupMemberService( rockContext );
-                var inGroups = groupMemberService.GetByPersonId( careNeed.PersonAlias.PersonId ).Where( gm => gm.Group != null && gm.Group.IsActive && !gm.Group.IsArchived && gm.Group.GroupTypeId == leaderRole.GroupTypeId && !gm.IsArchived && gm.GroupMemberStatus == GroupMemberStatus.Active ).Select( gm => gm.GroupId );
-
-                if ( inGroups.Any() )
-                {
-                    if ( enableLogging )
-                    {
-                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, In Groups Count: {1}, leaderRole.GroupTypeId: {2}", careNeed.Guid, inGroups.Count(), leaderRole.GroupTypeId ), "In Small Groups" );
-                    }
-                    var groupLeaders = groupMemberService.GetByGroupRoleId( leaderRole.Id ).Where( gm => inGroups.Contains( gm.GroupId ) && !gm.IsArchived && gm.GroupMemberStatus == GroupMemberStatus.Active );
-                    foreach ( var member in groupLeaders )
-                    {
-                        if ( !addedWorkerAliasIds.Contains( member.Person.PrimaryAliasId ) && careAssigneeService.GetByPersonAliasAndCareNeed( member.Person.PrimaryAliasId, careNeed.Id ) == null && member.PersonId != careNeed.PersonAlias.Person.Id )
-                        {
-                            var careAssignee = new AssignedPerson { Id = 0 };
-                            careAssignee.CareNeed = careNeed;
-                            careAssignee.PersonAliasId = member.Person.PrimaryAliasId;
-
-                            careAssigneeService.Add( careAssignee );
-                            addedWorkerAliasIds.Add( careAssignee.PersonAliasId );
-                        }
-                    }
-                    if ( enableLogging )
-                    {
-                        LogEvent( null, "AutoAssignWorkers", string.Format( "Care Need Guid: {0}, groupLeaders Count: {1} addedWorkerAliasIds Count: {2}", careNeed.Guid, groupLeaders.Count(), addedWorkerAliasIds.Count() ), "In Small Groups, Leader Count" );
-                    }
-
-                }
-            }
-            rockContext.SaveChanges();
-        }
-
-        private static IOrderedQueryable<WorkerResult> GenerateAgeQuery( CareNeed careNeed, IQueryable<CareWorker> careWorkersNoFence, int closedId, bool includeAgeRange, bool includeGender, bool includeCampus, bool includeCategory, bool ignoreAgeRangeAndGender = false )
-        {
-            var ageAsDecimal = ( decimal? ) careNeed.PersonAlias.Person.AgePrecise;
-            var tempQuery = careWorkersNoFence;
-
-            if ( includeAgeRange )
-            {
-                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && (
-                                                    ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
-                                                    ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
-                                                    ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
-                                                   )
-                                            );
-            }
-            else if ( !ignoreAgeRangeAndGender )
-            {
-                tempQuery = tempQuery.Where( cw => ageAsDecimal.HasValue && !(
-                                                     ( cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ( ageAsDecimal > cw.AgeRangeMin.Value && ageAsDecimal < cw.AgeRangeMax.Value ) ) ||
-                                                     ( !cw.AgeRangeMin.HasValue && cw.AgeRangeMax.HasValue && ageAsDecimal < cw.AgeRangeMax.Value ) ||
-                                                     ( cw.AgeRangeMin.HasValue && !cw.AgeRangeMax.HasValue && ageAsDecimal > cw.AgeRangeMin.Value )
-                                                    )
-                                            );
-            }
-
-            if ( includeGender )
-            {
-                tempQuery = tempQuery.Where( cw => cw.Gender == careNeed.PersonAlias.Person.Gender );
-            }
-            else if ( !ignoreAgeRangeAndGender )
-            {
-                tempQuery = tempQuery.Where( cw => cw.Gender != careNeed.PersonAlias.Person.Gender );
-            }
-
-            if ( includeCategory )
-            {
-                tempQuery = tempQuery.Where( cw => cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
-            }
-            else
-            {
-                tempQuery = tempQuery.Where( cw => !cw.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) );
-            }
-
-            if ( includeCampus )
-            {
-                tempQuery = tempQuery.Where( cw => cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
-            }
-            else
-            {
-                tempQuery = tempQuery.Where( cw => !cw.Campuses.Contains( careNeed.CampusId.ToString() ) );
-            }
-
-            return tempQuery.Select( cw => new WorkerResult
-                                        {
-                                            Count = cw.AssignedPersons.Where( ap => ap.CareNeed != null && ap.CareNeed.StatusValueId != closedId ).Count(),
-                                            Worker = cw,
-                                            HasCategory = includeCategory,
-                                            HasCampus = includeCampus,
-                                            HasAgeRange = includeAgeRange,
-                                            HasGender = includeGender
-                                        }
-                                    )
-                                    .OrderBy( cw => cw.Count )
-                                    .ThenBy( cw => cw.Worker.CategoryValues.Contains( careNeed.CategoryValueId.ToString() ) )
-                                    .ThenBy( cw => cw.Worker.Campuses.Contains( careNeed.CampusId.ToString() ) );
-        }
-
         /// <summary>
         /// Binds the Assigned Persons grid.
         /// </summary>
@@ -1478,53 +939,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             btnDeleteSelectedAssignedPersons.Visible = AssignedPersons.Any();
         }
 
-        private PageReference GetParentPage()
-        {
-            var pageCache = PageCache.Get( RockPage.PageId );
-            if ( pageCache != null )
-            {
-                var parentPage = pageCache.ParentPage;
-                if ( parentPage != null )
-                {
-                    return new PageReference( parentPage.Guid.ToString() );
-                }
-            }
-            return new PageReference( pageCache.Guid.ToString() );
-        }
-
-        private ServiceLog LogEvent( RockContext rockContext, string type, string input, string result )
-        {
-            if ( rockContext == null )
-            {
-                rockContext = new RockContext();
-            }
-
-            var rockLogger = new ServiceLogService( rockContext );
-            ServiceLog serviceLog = new ServiceLog
-            {
-                Name = "Steps To Care",
-                Type = type,
-                LogDateTime = RockDateTime.Now,
-                Input = input,
-                Result = result,
-                Success = true
-            };
-            rockLogger.Add( serviceLog );
-            rockContext.SaveChanges();
-            return serviceLog;
-        }
-
-
-        #endregion
-    }
-
-    public partial class WorkerResult
-    {
-        public int Count { get; set; }
-        public CareWorker Worker { get; set; }
-        public bool HasCategory { get; set; } = false;
-        public bool HasCampus { get; set; } = false;
-        public bool HasAgeRange { get; set; } = false;
-        public bool HasGender { get; set; } = false;
+        #endregion Methods
     }
 }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add the capability to schedule future needs and display them. In order to do so all the assignment methods were moved to a common utility class instead of being located in the Care Entry Block.

**New Settings:**

Care Dashboard
- **Threshold of Days For Future Need**, The number of days the need has to be within before displaying on the dashboard.

Care Entry   
- **Threshold of Days before Assignment**, The number of days you can schedule a need in the future before a need will be assigned to workers.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added capability to schedule future needs in Steps to Care.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

Care Dashboard, "Include Future Needs"
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/2990519/181621229-911e35a7-eaf6-41b4-9f77-df56e3e4a9e2.png">

<img width="886" alt="image" src="https://user-images.githubusercontent.com/2990519/181621485-e77000ba-5755-4404-87bf-1afd96db2f25.png">

Care Entry, new settings:
<img width="883" alt="image" src="https://user-images.githubusercontent.com/2990519/181621667-ab20cfee-9087-4c54-b4cc-46760c990b75.png">

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs
- StepsToCare/CareEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Yes, new DLL update is required with new utility methods. https://github.com/KingdomFirst/RockAssemblies/pull/83
