### PR TITLE
Shelby Financials Exception with multiple batches selected

### DIFF
--- a/ShelbyFinancials/BatchesToJournal.ascx.cs
+++ b/ShelbyFinancials/BatchesToJournal.ascx.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2019 by Kingdom First Solutions
+// Copyright 2022 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -352,14 +352,13 @@ namespace RockWeb.Plugins.rocks_kfs.ShelbyFinancials
 
                 var exportedBatches = batchService.Queryable()
                     .WhereAttributeValue( rockContext, a => a.Attribute.Key == "rocks.kfs.ShelbyFinancials.DateExported" && ( a.Value != null && a.Value != "" ) )
-                    .Select( b => b.Id )
-                    .ToList();
+                    .Select( b => b.Id );
 
                 batchesToUpdate = batchService.Queryable()
                     .Where( b =>
-                        selectedBatches.Contains( b.Id ) &&
-                        !exportedBatches.Contains( b.Id ) )
-                    .ToList();
+                        selectedBatches.Contains( b.Id )
+                        && !exportedBatches.Contains( b.Id )
+                      ).ToList();
 
                 foreach ( var batch in batchesToUpdate )
                 {
@@ -395,7 +394,7 @@ namespace RockWeb.Plugins.rocks_kfs.ShelbyFinancials
                     var journalCode = ddlJournalType.SelectedValue;
                     var period = tbAccountingPeriod.Text.AsInteger();
 
-                    items.AddRange( sfJournal.GetGLExcelLines( rockContext, batch, journalCode, period, ref debugLava, GetAttributeValue( "JournalDescriptionLava") ) );
+                    items.AddRange( sfJournal.GetGLExcelLines( rockContext, batch, journalCode, period, ref debugLava, GetAttributeValue( "JournalDescriptionLava" ) ) );
 
                     HistoryService.SaveChanges(
                         rockContext,


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for "Wait operation timed out" due to having too many integers in a NOT IN() SQL query when attempting to export multiple batches. Don't convert to list of Integers first so it can handle it with a SQL query instead. 

Previous Query (Not in could get 39,000+ integers in it): 
`SELECT ...
WHERE ... AND ( NOT ([Extent1].[Id] IN (...)))`

New Query:
`SELECT ...
WHERE ... AND ( NOT EXISTS (SELECT ...`

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed potential "Wait operation timed out" error when exporting multiple batches at the same time.

---------

### Requested By

##### Who reported, requested, or paid for the change?

College

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

ShelbyFinancials/BatchesToJournal.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
