### PR TITLE
Person Attributes Advanced - Family Member Mode

### DIFF
--- a/Crm/PersonAttributeForms.ascx
+++ b/Crm/PersonAttributeForms.ascx
@@ -62,6 +62,12 @@
 
             <asp:Literal ID="lHeader" runat="server" />
 
+            <asp:Panel ID="pnlFamilyMembers" runat="server" Visible="false" CssClass="row">
+                <div class="col-md-12">
+                    <Rock:RockDropDownList ID="ddlFamilyMembers" runat="server" Label="Select a Family Member" AutoPostBack="true" OnSelectedIndexChanged="ddlFamilyMembers_SelectedIndexChanged" />
+                </div>
+            </asp:Panel>
+
             <asp:PlaceHolder ID="phContent" runat="server" />
 
             <asp:Literal ID="lFooter" runat="server" />
@@ -96,7 +102,7 @@
                                     <div class="col-md-4">
                                         <Rock:WorkflowTypePicker ID="wtpWorkflow" runat="server" Label="Workflow"
                                             Help="An optional workflow to launch after the person has filled out all of the forms." />
-                                         <Rock:RockDropDownList ID="ddlWorkflowEntity" runat="server" Label="Workflow Entity"
+                                        <Rock:RockDropDownList ID="ddlWorkflowEntity" runat="server" Label="Workflow Entity"
                                             Help="The entity that should be used to initiate the workflow.">
                                             <asp:ListItem Value="Person" Text="Person" />
                                             <asp:ListItem Value="ConnectionRequest" Text="Connection Request" />

--- a/Crm/PersonAttributeForms.ascx.cs
+++ b/Crm/PersonAttributeForms.ascx.cs
@@ -68,7 +68,7 @@ namespace RockWeb.Plugins.rocks_kfs.Crm
     [CustomRadioListField( "Group Member Status", "The group member status to use when adding person to group (default: 'Pending'.)", "2^Pending,1^Active,0^Inactive", true, "2", "Groups", 4 )]
     [BooleanField( "Display SMS Checkbox on Mobile Phone", "Should we show the SMS checkbox when a mobile phone is displayed on the form?", false )]
     [CustomDropdownListField( "Person Mode", "Person selection mode, should we allow family members, any person guid, or logged in user only.", "Family Members,Anyone,Logged in Person only", true, "Family Members" )]
-    [BooleanField( "Display Family Member Picker", "Should we show the family member picker on the form? (Note: this will only display in Family Members or Anyone "Person Mode".) Default: false", false )]
+    [BooleanField( "Display Family Member Picker", "Should we show the family member picker on the form? (Note: this will only display in Family Members or Anyone \"Person Mode\".) Default: false", false )]
     [BooleanField( "Display Progress Bar", "Determines if the progress bar should be show if there is more than one form.", true, "CustomSetting" )]
     [CustomDropdownListField( "Save Values", "", "PAGE,END", true, "END", "CustomSetting" )]
     [WorkflowTypeField( "Workflow", "The workflow to be launched when complete.", false, false, "", "CustomSetting" )]

--- a/Crm/PersonAttributeForms.ascx.cs
+++ b/Crm/PersonAttributeForms.ascx.cs
@@ -260,14 +260,13 @@ namespace RockWeb.Plugins.rocks_kfs.Crm
 
                     if ( displayFamilyMemberPicker && personMode != "Logged in Person only" )
                     {
-
                         var familyMembers = _person.GetFamilyMembers( true )
                                         .Select( m => m.Person )
                                         .ToList();
 
-                        if ( familyMembers.Any() )
+                        if ( familyMembers.Count() > 1 )
                         {
-                            ddlFamilyMembers.Visible = true;
+                            pnlFamilyMembers.Visible = true;
                             ddlFamilyMembers.Items.Add( new ListItem() );
 
                             foreach ( var familyMember in familyMembers )
@@ -277,8 +276,6 @@ namespace RockWeb.Plugins.rocks_kfs.Crm
                                 ddlFamilyMembers.Items.Add( listItem );
                             }
                         }
-                        pnlFamilyMembers.Visible = ddlFamilyMembers.Items.Count > 0;
-
                     }
                     else
                     {
@@ -941,7 +938,7 @@ namespace RockWeb.Plugins.rocks_kfs.Crm
         {
             var qs = new Dictionary<string, string>();
             qs.Add( "Person", ddlFamilyMembers.SelectedValueAsGuid().ToString() );
-            NavigateToCurrentPage( qs );
+            NavigateToCurrentPageReference( qs );
         }
 
         #region Form Control Events

--- a/Crm/PersonAttributeForms_Readme.md
+++ b/Crm/PersonAttributeForms_Readme.md
@@ -3,7 +3,7 @@
 # Person Attributes Form Advanced Block
 *Tested/Supported in Rock version:  8.0-13.0*   
 *Created:  11/20/2018*  
-*Updated:  2/2/2022*   
+*Updated:  8/9/2022*   
 *Rock Shop Plugin: https://www.rockrms.com/Plugin/101*
 
 ## Summary
@@ -33,7 +33,8 @@ Quick Links:
 
 The following new goodness will be added to your Rock install with this plugin:
 
-- **New Block**: Person Attribute Forms Advanced
+- Added ability to run this block in **Person Mode** which can be run as any person with guid in the url, family members, or only logged in users. See [Block Properties](#block-properties) for more information.
+- Added an option to **Display Family Member Picker** to work in tandem with this new mode.
 
 
 
@@ -119,17 +120,22 @@ The possibilities are endless. Want to automate your process for Baptisms? Need 
 
 ## Block Properties
 
-![BlockPropertiesBasic (1)](https://user-images.githubusercontent.com/81330042/118964828-90446380-b92d-11eb-8dfa-ed25aa786070.png)
+![BlockProperties](https://user-images.githubusercontent.com/2990519/183775785-c1d960b9-7a68-41dd-8f39-156d6022030e.jpg)
 
-
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;1&nbsp;&nbsp;</span>**Allow Connection Opportunity** Determines if a URL parameter of OpportunityId should be evaluated when complete. 
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;1&nbsp;&nbsp;</span>**Display Family Member Picker** Should we show the family member picker on the form? (Note: this will only display in Family Members or Anyone "Person Mode".)
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;2&nbsp;&nbsp;</span>**Allow Group Membership** Determines if a URL parameter of GroupGuid or GroupId should be evaluated when complete
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;2&nbsp;&nbsp;</span>**Display SMS Checkbox on Mobile Phone** Should we show the SMS checkbox when a mobile phone is displayed on the form? 
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;3&nbsp;&nbsp;</span>**Enable Passing Group Id** If enabled, allows the passing of the GroupId instead of the GroupGuid
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;3&nbsp;&nbsp;</span>**Person Mode** You can use this block to edit other person's information by passing a Person Guid via a URL Parameter `?Person=<guid>`, this setting narrows the option down for security purposes, you can allow family members, any person guid, or the logged in user only. The default value is "Family Members" so you can use it with the "Display Family Member Picker" option above.
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;4&nbsp;&nbsp;</span>**Allowed Group Types** This setting restricts which types of groups a person can be added to, however selecting a specific group via the Group setting will override this restriction.
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;4&nbsp;&nbsp;</span>**Allow Connection Opportunity** Determines if a URL parameter of OpportunityId should be evaluated when complete. 
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;5&nbsp;&nbsp;</span>**Group** Optional group to add the person to. If omitted, the group's Guid should be passed via the query string
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;5&nbsp;&nbsp;</span>**Allow Group Membership** Determines if a URL parameter of GroupGuid or GroupId should be evaluated when complete
 >
-> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;6&nbsp;&nbsp;</span>**Group Member Status** The group member status to use when adding person to group
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;6&nbsp;&nbsp;</span>**Enable Passing Group Id** If enabled, allows the passing of the GroupId instead of the GroupGuid
+>
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;7&nbsp;&nbsp;</span>**Allowed Group Types** This setting restricts which types of groups a person can be added to, however selecting a specific group via the Group setting will override this restriction.
+>
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;8&nbsp;&nbsp;</span>**Group** Optional group to add the person to. If omitted, the group's Guid should be passed via the query string
+>
+> <span style="padding-left: 30px; margin-right: 10px; width: .8em;background: #d21919; border-radius: 100%; color: white; text-align: center; display: inline-block;">&nbsp;&nbsp;9&nbsp;&nbsp;</span>**Group Member Status** The group member status to use when adding person to group


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added ability to run Person Attribute Forms Advanced in "Person Mode" that can be any person with guid, family members, or only logged in users. Also added a select a family member dropdown when not in only logged in users mode.

**New Settings:**

*Person Mode*, Person selection mode, should we allow family members, any person guid, or logged in user only.

*Display Family Member Picker*, Should we show the family member picker on the form? (Note: this will only display in Family Members or Anyone mode.)

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added ability to run Person Attribute Forms Advanced in "Person Mode" that can be any person with guid, family members, or only logged in users.
- Added an option to "Display a Family Member Picker" to work in tandem with this new mode.

---------

### Requested By

##### Who reported, requested, or paid for the change?

VWC

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/182974464-a3c025d3-846d-4df9-9df9-6801f1d9e7b9.png)

![image](https://user-images.githubusercontent.com/2990519/182974687-a06c98f7-1af7-4c0c-a3bc-fd1758955bc6.png)

![image](https://user-images.githubusercontent.com/2990519/182974746-2967aafb-6171-408c-8c22-28965535de9a.png)

---------

### Change Log

##### What files does it affect?

- Crm/PersonAttributeForms.ascx
- Crm/PersonAttributeForms.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
