### PR TITLE
SMS Conversations Modifications

### DIFF
--- a/Communication/SmsConversations.ascx
+++ b/Communication/SmsConversations.ascx
@@ -2,7 +2,8 @@
 
 <asp:UpdatePanel ID="upPanel" runat="server">
     <ContentTemplate>
-        <Rock:NotificationBox ID="nbNoNumbers" runat="server" NotificationBoxType="Warning" Text='No "SMS Phone Numbers" are available to view. Either there are none configured or you do not have access to them.' Visible="false"></Rock:NotificationBox>
+        <Rock:NotificationBox ID="nbNoNumbers" runat="server" NotificationBoxType="Warning" Text='No "SMS Phone Numbers" are available to view. Either there are none configured or you do not have access to them.' Visible="false" ></Rock:NotificationBox>
+        <Rock:NotificationBox ID="nbError" runat="server" NotificationBoxType="Warning" Text='' Visible="false"></Rock:NotificationBox>
 
         <div class="panel panel-block" runat="server" id="divMain" visible="false">
 
@@ -76,7 +77,7 @@
 
                     <asp:UpdatePanel ID="upConversation" runat="server" class="conversation-panel">
                         <ContentTemplate>
-                            <Rock:HiddenFieldWithClass ID="hfSelectedRecipientPersonAliasId" runat="server" CssClass="js-selected-recipient-id" />
+                            <Rock:HiddenFieldWithClass ID="hfSelectedRecipientPersonAliasId" runat="server" CssClass="js-selected-recipient-personalias-id" />
                             <Rock:HiddenFieldWithClass ID="hfSelectedMessageKey" runat="server" CssClass="js-selected-message-key" />
                             <div class="header">
                                 <a href="#" class="conversation-back js-back pull-left mr-3">
@@ -92,7 +93,7 @@
                                         <asp:Repeater ID="rptConversation" runat="server" OnItemDataBound="rptConversation_ItemDataBound" Visible="false">
                                             <ItemTemplate>
                                                 <div class="message outbound" id="divCommunication" runat="server">
-                                                    <Rock:HiddenFieldWithClass ID="hfCommunicationRecipientId" runat="server" />
+                                                    <Rock:HiddenFieldWithClass ID="hfCommunicationRecipientPersonAliasId" runat="server" />
                                                     <Rock:HiddenFieldWithClass ID="hfCommunicationMessageKey" runat="server" />
                                                     <%-- Keep divCommunicationBody and lSMSMessage on same line for rendering --%>
                                                     <div class="bubble" id="divCommunicationBody" runat="server"><asp:Literal ID="lSMSMessage" runat="server" /></div>

--- a/Communication/SmsConversations.ascx
+++ b/Communication/SmsConversations.ascx
@@ -1,0 +1,225 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="SmsConversations.ascx.cs" Inherits="RockWeb.Plugins.rocks_kfs.Communication.SmsConversations" %>
+
+<asp:UpdatePanel ID="upPanel" runat="server">
+    <ContentTemplate>
+        <Rock:NotificationBox ID="nbNoNumbers" runat="server" NotificationBoxType="Warning" Text='No "SMS Phone Numbers" are available to view. Either there are none configured or you do not have access to them.' Visible="false"></Rock:NotificationBox>
+
+        <div class="panel panel-block" runat="server" id="divMain" visible="false">
+
+            <div class="panel-heading panel-follow">
+                <h1 class="panel-title"><i class="fa fa-comments"></i>SMS Conversations</h1>
+
+
+                <div class="panel-labels m-0">
+                    <!--  style="position:absolute;right:15px;top:10px;" -->
+                    <Rock:HighlightLabel ID="hlSmsNumber" runat="server" CssClass="pull-left input-width-lg input-xs" />
+                    <asp:HiddenField ID="hfSmsNumber" runat="server" />
+                    <Rock:RockDropDownList ID="ddlSmsNumbers" runat="server" Label="" AutoPostBack="true" OnSelectedIndexChanged="ddlSmsNumbers_SelectedIndexChanged" CssClass="pull-left input-width-lg input-xs" />
+
+                    <a href="#" class="btn btn-xs btn-default btn-square ml-2 pull-left" onclick="$('.js-sms-configuration').slideToggle()">
+                        <i class="fa fa-cog"></i>
+                    </a>
+                </div>
+                <div class="rock-fullscreen-toggle js-fullscreen-trigger"></div>
+            </div>
+
+            <div class="js-sms-configuration" style="display: none">
+                <div class="well mb-0 border-top-0 border-right-0 border-left-0 rounded-0">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <%-- The list of phone numbers that do not have "Enable Mobile Conversations" enabled --%>
+                            <Rock:Toggle ID="tglShowRead" runat="server" Label="Show Read Messages" OnCheckedChanged="tglShowRead_CheckedChanged" OnText="Yes" OffText="No" Checked="true" ButtonSizeCssClass="btn-sm" />
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <div class="sms-conversations-parent">
+                <div class="sms-conversations-container styled-scroll">
+                    <div class="conversation-list d-flex flex-column">
+                        <div class="header">
+                            <div class="clearfix">
+                                <asp:LinkButton ID="btnCreateNewMessage" runat="server" CssClass="btn btn-default btn-sm btn-square" OnClick="btnCreateNewMessage_Click" ToolTip="New Message"><i class="fa fa-edit"></i></asp:LinkButton>
+                                <asp:LinkButton ID="lbPersonFilter" runat="server" CssClass="btn btn-default btn-sm btn-square pull-right" OnClientClick="$('.js-person-filter').slideToggle(); return false;"><i class="fa fa-filter"></i></asp:LinkButton>
+                            </div>
+                            <div id="divPersonFilter" runat="server" class="js-person-filter" style="display: none;">
+                                <Rock:PersonPicker ID="ppPersonFilter" runat="server" Label="Recipient" OnSelectPerson="ppPersonFilter_SelectPerson" FormGroupCssClass="mt-2 mb-0" />
+                            </div>
+                        </div>
+                        <asp:UpdatePanel ID="upRecipients" runat="server" class="overflow-scroll">
+                            <ContentTemplate>
+                                <Rock:Grid ID="gRecipients" runat="server" OnRowSelected="gRecipients_RowSelected" OnRowDataBound="gRecipients_RowDataBound" ShowHeader="false" ShowActionRow="false" DisplayType="Light" EnableResponsiveTable="False">
+                                    <Columns>
+                                        <Rock:RockBoundField DataField="RecipientPersonAliasId" Visible="false"></Rock:RockBoundField>
+                                        <Rock:RockTemplateField>
+                                            <ItemTemplate>
+                                                <Rock:HiddenFieldWithClass ID="hfRecipientPersonAliasId" runat="server" CssClass="js-recipientId" />
+                                                <Rock:HiddenFieldWithClass ID="hfMessageKey" runat="server" CssClass="js-messageKey" />
+
+                                                <div class="layout-row">
+                                                    <asp:Label ID="lblName" runat="server" Class="sms-name" />
+                                                    <div class="date">
+                                                        <asp:Literal ID="litDateTime" runat="server" />
+                                                    </div>
+                                                </div>
+                                                <div class="message-truncate">
+                                                    <asp:Literal ID="litMessagePart" runat="server" />
+                                                </div>
+                                            </ItemTemplate>
+                                        </Rock:RockTemplateField>
+                                    </Columns>
+                                </Rock:Grid>
+                            </ContentTemplate>
+                        </asp:UpdatePanel>
+                    </div>
+
+                    <asp:UpdatePanel ID="upConversation" runat="server" class="conversation-panel">
+                        <ContentTemplate>
+                            <Rock:HiddenFieldWithClass ID="hfSelectedRecipientPersonAliasId" runat="server" CssClass="js-selected-recipient-id" />
+                            <Rock:HiddenFieldWithClass ID="hfSelectedMessageKey" runat="server" CssClass="js-selected-message-key" />
+                            <div class="header">
+                                <a href="#" class="conversation-back js-back pull-left mr-3">
+                                    <i class="fa fa-chevron-left"></i>
+                                </a>
+                                <asp:Literal ID="litSelectedRecipientDescription" runat="server"></asp:Literal>
+                                <asp:LinkButton ID="lbLinkConversation" runat="server" Text="Link To Person" Visible="false" CausesValidation="false" CssClass="btn btn-default btn-xs pull-right" OnClick="lbLinkConversation_Click"></asp:LinkButton>
+                                <asp:LinkButton ID="lbViewMergeRequest" runat="server" Text="View Merge Request" Visible="false" CausesValidation="false" CssClass="btn btn-default btn-xs pull-right" OnClick="lbViewMergeRequest_Click"></asp:LinkButton>
+                            </div>
+                            <div class="messages-outer-container">
+                                <div class="messages-scroll-container">
+                                    <div class="conversation">
+                                        <asp:Repeater ID="rptConversation" runat="server" OnItemDataBound="rptConversation_ItemDataBound" Visible="false">
+                                            <ItemTemplate>
+                                                <div class="message outbound" id="divCommunication" runat="server">
+                                                    <Rock:HiddenFieldWithClass ID="hfCommunicationRecipientId" runat="server" />
+                                                    <Rock:HiddenFieldWithClass ID="hfCommunicationMessageKey" runat="server" />
+                                                    <%-- Keep divCommunicationBody and lSMSMessage on same line for rendering --%>
+                                                    <div class="bubble" id="divCommunicationBody" runat="server"><asp:Literal ID="lSMSMessage" runat="server" /></div>
+                                                    <div id="divCommicationAttachments" runat="server">
+                                                        <asp:Literal ID="lSMSAttachments" runat="server" /></div>
+                                                    <div class="message-meta">
+                                                        <span class="sender-name">
+                                                            <asp:Literal ID="lSenderName" runat="server" /></span>
+                                                        <asp:Label ID="lblMessageDateTime" runat="server" CssClass="date" />
+                                                    </div>
+                                                </div>
+                                            </ItemTemplate>
+                                            <FooterTemplate>
+                                                <asp:Label ID="lblNoConversationsFound" runat="server" Visible='<%# rptConversation.Items.Count == 0 %>' Text="<tr><td>No conversations found.</td></tr>" CssClass="text-muted" />
+                                            </FooterTemplate>
+                                        </asp:Repeater>
+                                    </div>
+                                </div>
+                                <div class="js-send-image sms-image-uploader-container" style="display: none;">
+                                    <asp:LinkButton ID="lbDismiss" runat="server" CssClass="close" OnClientClick="$('.js-send-image').slideToggle(); return false;"><i class="fa fa-times"></i></asp:LinkButton>
+                                    <div class="sms-image-uploader">
+                                        <Rock:ImageUploader ID="ImageUploaderConversation" runat="server" BinaryFileTypeGuid="<%# new Guid( Rock.SystemGuid.BinaryFiletype.COMMUNICATION_ATTACHMENT ) %>" Help="Optional image to include in the message." Label="Image" />
+                                    </div>
+                                </div>
+
+                            </div>
+                            <div class="js-notecontainer">
+                                <Rock:NoteEditor ID="noteEditor" runat="server" CssClass="sms-conversation-note-editor" Visible="false" />
+                            </div>
+                            <div class="footer">
+                                <Rock:RockTextBox ID="tbNewMessage" runat="server" TextMode="multiline" Rows="1" Placeholder="Type a message" CssClass="js-input-message rounded-0" Visible="false" autofocus></Rock:RockTextBox>
+                                <div class="actions">
+                                    <asp:LinkButton ID="btnEditNote" runat="server" CssClass="btn btn-default btn-square edit-note-button" OnClick="btnEditNote_Click" ToolTip="Add Note" ><i class="fa fa-edit"></i></asp:LinkButton>
+                                    <asp:LinkButton ID="lbShowImagePicker" runat="server" CssClass="btn btn-default image-button btn-square" OnClientClick="$('.js-send-image').slideToggle(); return false;"><i class="fa fa-camera"></i></asp:LinkButton>
+                                    <Rock:BootstrapButton ID="btnSend" runat="server" CssClass="btn btn-primary send-button js-send-text-button" Text="Send" DataLoadingText="Sending..." OnClick="btnSend_Click" Visible="false" />
+                                </div>
+                            </div>
+                        </ContentTemplate>
+                    </asp:UpdatePanel>
+                </div>
+            </div>
+
+            <script>
+                Sys.Application.add_load(function () {
+                    Rock.controls.fullScreen.initialize('body');
+                    var objDiv = $(".messages-scroll-container")[0];
+                    objDiv.scrollTop = objDiv.scrollHeight;
+
+                    $("#<%=upConversation.ClientID %> .js-back").on("click", function () {
+                        $('#<%=upConversation.ClientID %>').removeClass("has-focus");
+                        return false;
+                    });
+                });
+
+                var yPos;
+                var prm = Sys.WebForms.PageRequestManager.getInstance();
+
+                function BeginRequestHandler(sender, args) {
+                    if ($('#<%=upRecipients.ClientID %>') != null) {
+                        // Get X and Y positions of scrollbar before the partial postback
+                        yPos = $('#<%=upRecipients.ClientID %>').scrollTop();
+                    }
+                }
+
+                function EndRequestHandler(sender, args) {
+                    if ($('#<%=upRecipients.ClientID %>') != null) {
+                        // Set X and Y positions back to the scrollbar
+                        // after partial postback
+                        $('#<%=upRecipients.ClientID %>').scrollTop(yPos);
+                        $('#<%=tbNewMessage.ClientID %>').focus();
+                    }
+                }
+
+                prm.add_beginRequest(BeginRequestHandler);
+                prm.add_endRequest(EndRequestHandler);
+            </script>
+        </div>
+        <%-- End panel-block --%>
+
+        <asp:HiddenField ID="hfActiveDialog" runat="server" />
+
+        <Rock:ModalDialog ID="mdNewMessage" runat="server" Title="New Message" OnSaveClick="mdNewMessage_SaveClick" SaveButtonText="Send" ValidationGroup="vgMobileTextEditor">
+            <Content>
+                <asp:ValidationSummary ID="vsMobileTextEditor" runat="server" HeaderText="Please correct the following:" ValidationGroup="vgMobileTextEditor" CssClass="alert alert-validation" />
+                <Rock:NotificationBox ID="nbNoSms" runat="server" Text="The selected person does not have an SMS enabled Phone number." Dismissable="true" Visible="false" NotificationBoxType="Warning"></Rock:NotificationBox>
+                <div class="form-group">
+                    <label runat="server" id="lblFromNumber" class="control-label">From</label>
+                    <div>
+                        <asp:Label ID="lblMdNewMessageSendingSMSNumber" runat="server" />
+                    </div>
+                </div>
+
+                <%-- person picker --%>
+                <Rock:PersonPicker ID="ppRecipient" runat="server" Label="Recipient" ValidationGroup="vgMobileTextEditor" RequiredErrorMessage="Please select an SMS recipient." Required="true" OnSelectPerson="ppRecipient_SelectPerson" />
+
+                <%-- multi-line textbox --%>
+                <div class="form-group">
+                    <Rock:RockTextBox ID="tbSMSTextMessage" runat="server" CssClass="js-sms-text-message" TextMode="MultiLine" Rows="3" Placeholder="Type a message" Required="true" ValidationGroup="vgMobileTextEditor" RequiredErrorMessage="Message is required" ValidateRequestMode="Disabled" />
+                </div>
+
+                <%-- image uploader --%>
+                <Rock:ImageUploader ID="ImageUploaderModal" runat="server" BinaryFileTypeGuid="<%# new Guid( Rock.SystemGuid.BinaryFiletype.COMMUNICATION_ATTACHMENT ) %>" Help="Optional image to include in the message." Label="Image" />
+            </Content>
+        </Rock:ModalDialog>
+
+        <%-- Link to Person --%>
+        <Rock:ModalDialog ID="mdLinkToPerson" runat="server" Title="Link Phone Number to Person" OnSaveClick="mdLinkToPerson_SaveClick" ValidationGroup="vgLinkToPerson">
+            <Content>
+                <asp:HiddenField ID="hfNamelessPersonId" runat="server" />
+
+                <Rock:NotificationBox ID="nbMergeRequestCreated" runat="server" Heading="To prevent data loss and to ensure the highest level of security, a merge request will be created upon pressing Save." NotificationBoxType="Info" Visible="true" />
+                <Rock:NotificationBox ID="nbAddPerson" runat="server" Heading="Please correct the following:" NotificationBoxType="Danger" Visible="false" />
+                <asp:ValidationSummary ID="valSummaryAddPerson" runat="server" HeaderText="Please correct the following:" CssClass="alert alert-validation" ValidationGroup="vgLinkToPerson" />
+
+                <Rock:Toggle ID="tglLinkPersonMode" runat="server" OnText="Link Existing Person" CssClass="mb-3" OffText="Add New Person" ActiveButtonCssClass="btn-primary" OnCheckedChanged="tglLinkPersonMode_CheckedChanged" />
+
+                <asp:Panel ID="pnlLinkToNewPerson" runat="server">
+                    <Rock:PersonBasicEditor ID="newPersonEditor" runat="server" ValidationGroup="vgLinkToPerson" />
+                </asp:Panel>
+
+                <asp:Panel ID="pnlLinkToExistingPerson" runat="server" Visible="false">
+                    <fieldset>
+                        <Rock:PersonPicker ID="ppPerson" runat="server" Label="Person" Required="true" ValidationGroup="vgLinkToPerson" />
+                    </fieldset>
+                </asp:Panel>
+
+            </Content>
+        </Rock:ModalDialog>
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/Communication/SmsConversations.ascx
+++ b/Communication/SmsConversations.ascx
@@ -45,7 +45,8 @@
                                 <asp:LinkButton ID="lbPersonFilter" runat="server" CssClass="btn btn-default btn-sm btn-square pull-right" OnClientClick="$('.js-person-filter').slideToggle(); return false;"><i class="fa fa-filter"></i></asp:LinkButton>
                             </div>
                             <div id="divPersonFilter" runat="server" class="js-person-filter" style="display: none;">
-                                <Rock:PersonPicker ID="ppPersonFilter" runat="server" Label="Recipient" OnSelectPerson="ppPersonFilter_SelectPerson" FormGroupCssClass="mt-2 mb-0" />
+                                <Rock:PersonPicker ID="ppPersonFilter" runat="server" Label="Recipient" OnSelectPerson="ppPersonFilter_SelectPerson" FormGroupCssClass="mt-2" />
+                                <Rock:RockCheckBox ID="cbShowInbound" runat="server" Text="Show Inbound Only" FormGroupCssClass="mt-2 mb-0" OnCheckedChanged="cbShowInbound_CheckedChanged" AutoPostBack="true" />
                             </div>
                         </div>
                         <asp:UpdatePanel ID="upRecipients" runat="server" class="overflow-scroll">

--- a/Communication/SmsConversations.ascx.cs
+++ b/Communication/SmsConversations.ascx.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Linq;
+using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
 
@@ -26,10 +27,12 @@ using Rock;
 using Rock.Attribute;
 using Rock.Data;
 using Rock.Model;
+using Rock.Reporting;
 using Rock.Security;
 using Rock.Web.Cache;
 using Rock.Web.UI;
 using Rock.Web.UI.Controls;
+using Twilio.Rest;
 
 namespace RockWeb.Plugins.rocks_kfs.Communication
 {
@@ -98,6 +101,15 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         Order = 7,
         Key = AttributeKey.NoteTypes )]
 
+
+    [IntegerField(
+        "Database Timeout",
+        Key = AttributeKey.DatabaseTimeoutSeconds,
+        Description = "The number of seconds to wait before reporting a database timeout.",
+        IsRequired = false,
+        DefaultIntegerValue = 180,
+        Order = 8 )]
+
     public partial class SmsConversations : RockBlock
     {
         #region Attribute Keys
@@ -111,6 +123,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             public const string MaxConversations = "MaxConversations";
             public const string PersonInfoLavaTemplate = "PersonInfoLavaTemplate";
             public const string NoteTypes = "NoteTypes";
+            public const string DatabaseTimeoutSeconds = "DatabaseTimeoutSeconds";
         }
 
         #endregion Attribute Keys
@@ -140,6 +153,15 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             ConfigureNoteEditor();
 
             btnCreateNewMessage.Visible = this.GetAttributeValue( AttributeKey.EnableSmsSend ).AsBoolean();
+
+            //// Set postback timeout and request-timeout to whatever the DatabaseTimeout is plus an extra 5 seconds so that page doesn't timeout before the database does
+            int databaseTimeout = GetAttributeValue( AttributeKey.DatabaseTimeoutSeconds ).AsIntegerOrNull() ?? 180;
+            var sm = ScriptManager.GetCurrent( this.Page );
+            if ( sm.AsyncPostBackTimeout < databaseTimeout + 5 )
+            {
+                sm.AsyncPostBackTimeout = databaseTimeout + 5;
+                Server.ScriptTimeout = databaseTimeout + 5;
+            }
         }
 
         /// <summary>
@@ -279,32 +301,57 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 return;
             }
 
-            using ( var rockContext = new RockContext() )
+            try
             {
-                var communicationResponseService = new CommunicationResponseService( rockContext );
+                using ( var rockContext = new RockContext() )
+                {
+                    rockContext.Database.CommandTimeout = GetAttributeValue( AttributeKey.DatabaseTimeoutSeconds ).AsIntegerOrNull() ?? 180;
 
-                int months = GetAttributeValue( AttributeKey.ShowConversationsFromMonthsAgo ).AsInteger();
+                    var communicationResponseService = new CommunicationResponseService( rockContext );
 
-                var startDateTime = RockDateTime.Now.AddMonths( -months );
-                bool showRead = tglShowRead.Checked;
+                    int months = GetAttributeValue( AttributeKey.ShowConversationsFromMonthsAgo ).AsInteger();
 
-                var maxConversations = this.GetAttributeValue( AttributeKey.MaxConversations ).AsIntegerOrNull() ?? 1000;
+                    var startDateTime = RockDateTime.Now.AddMonths( -months );
+                    bool showRead = tglShowRead.Checked;
 
-                var responseListItems = communicationResponseService.GetCommunicationResponseRecipients( smsPhoneDefinedValueId.Value, startDateTime, showRead, maxConversations, personId );
+                    var maxConversations = this.GetAttributeValue( AttributeKey.MaxConversations ).AsIntegerOrNull() ?? 1000;
 
-                // don't display conversations if we're rebinding the recipient list
-                rptConversation.Visible = false;
-                gRecipients.DataSource = responseListItems;
-                gRecipients.DataBind();
+                    var responseListItems = communicationResponseService.GetCommunicationResponseRecipients( smsPhoneDefinedValueId.Value, startDateTime, showRead, maxConversations, personId );
+
+                    // don't display conversations if we're rebinding the recipient list
+                    rptConversation.Visible = false;
+                    gRecipients.DataSource = responseListItems;
+                    gRecipients.DataBind();
+                }
+            }
+            catch ( Exception ex )
+            {
+                this.LogException( ex );
+                var sqlTimeoutException = ReportingHelper.FindSqlTimeoutException( ex );
+                if ( sqlTimeoutException != null )
+                {
+                    nbError.NotificationBoxType = NotificationBoxType.Warning;
+                    nbError.Text = "Unable to load SMS responses in a timely manner. You can try again or adjust the timeout setting of this block.";
+                    nbError.Visible = true;
+                    return;
+                }
+                else
+                {
+                    nbError.NotificationBoxType = NotificationBoxType.Danger;
+                    nbError.Text = "An error occurred when loading SMS responses";
+                    nbError.Details = ex.Message;
+                    nbError.Visible = true;
+                    return;
+                }
             }
         }
 
         /// <summary>
         /// Loads the responses for recipient.
         /// </summary>
-        /// <param name="recipientPersonAliasId">The recipient person alias identifier.</param>
+        /// <param name="recipientPersonId">The recipient person identifier.</param>
         /// <returns></returns>
-        private string LoadResponsesForRecipient( int recipientPersonAliasId )
+        private string LoadResponsesForRecipientPerson( int recipientPersonId )
         {
             int? smsPhoneDefinedValueId = hfSmsNumber.ValueAsInt();
 
@@ -313,21 +360,47 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 return string.Empty;
             }
 
-            var communicationResponseService = new CommunicationResponseService( new RockContext() );
-            List<CommunicationRecipientResponse> responses = communicationResponseService.GetCommunicationConversation( recipientPersonAliasId, smsPhoneDefinedValueId.Value );
-
-            BindConversationRepeater( responses );
-
-            if ( responses.Any() )
+            try
             {
-                var responseListItem = responses.Last();
+                var rockContext = new RockContext();
+                rockContext.Database.CommandTimeout = GetAttributeValue( AttributeKey.DatabaseTimeoutSeconds ).AsIntegerOrNull() ?? 180;
+                var communicationResponseService = new CommunicationResponseService( rockContext );
+                List<CommunicationRecipientResponse> responses = communicationResponseService.GetCommunicationConversationForPerson( recipientPersonId, smsPhoneDefinedValueId.Value );
 
-                if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.BinaryFileGuids != null && responseListItem.BinaryFileGuids.Any() )
+                BindConversationRepeater( responses );
+
+                if ( responses.Any() )
                 {
-                    return "Rock-Image-File";
-                }
+                    var responseListItem = responses.Last();
 
-                return responses.Last().SMSMessage;
+                    if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.HasAttachments( rockContext ) )
+                    {
+                        return "Rock-Image-File";
+                    }
+
+                    return responses.Last().SMSMessage;
+                }
+            }
+            catch ( Exception ex )
+            {
+                this.LogException( ex );
+                var sqlTimeoutException = ReportingHelper.FindSqlTimeoutException( ex );
+                var errorBox = nbError;
+
+                if ( sqlTimeoutException != null )
+                {
+                    nbError.NotificationBoxType = NotificationBoxType.Warning;
+                    nbError.Text = "Unable to load SMS responses for recipient in a timely manner. You can try again or adjust the timeout setting of this block.";
+                    return string.Empty;
+                }
+                else
+                {
+                    errorBox.NotificationBoxType = NotificationBoxType.Danger;
+                    nbError.Text = "An error occurred when loading SMS responses for recipient";
+                    errorBox.Details = ex.Message;
+                    errorBox.Visible = true;
+                    return string.Empty;
+                }
             }
 
             return string.Empty;
@@ -405,10 +478,10 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         /// <summary>
         /// Sends the message.
         /// </summary>
-        /// <param name="toPersonAliasId">To person alias identifier.</param>
+        /// <param name="toPersonId">To person identifier.</param>
         /// <param name="message">The message.</param>
         /// <param name="newMessage">if set to <c>true</c> [new message].</param>
-        private void SendMessage( int toPersonAliasId, string message, bool newMessage )
+        private void SendMessageToPerson( int toPersonId, string message, bool newMessage )
         {
             using ( var rockContext = new RockContext() )
             {
@@ -435,10 +508,12 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                     binaryFile = new BinaryFileService( rockContext ).Get( ImageUploaderModal.BinaryFileId.Value );
                 }
 
-                photos = binaryFile.IsNotNull() ? new List<BinaryFile> { binaryFile } : null;
+                photos = binaryFile != null ? new List<BinaryFile> { binaryFile } : null;
+
+                var toPrimaryAliasId = new PersonAliasService( rockContext ).GetPrimaryAliasId( toPersonId );
 
                 // Create and enqueue the communication
-                Rock.Communication.Medium.Sms.CreateCommunicationMobile( CurrentUser.Person, toPersonAliasId, message, fromPhone, responseCode, rockContext, photos );
+                Rock.Communication.Medium.Sms.CreateCommunicationMobile( CurrentUser.Person, toPrimaryAliasId, message, fromPhone, responseCode, rockContext, photos );
                 ImageUploaderConversation.BinaryFileId = null;
             }
         }
@@ -571,9 +646,16 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             }
 
             int toPersonAliasId = hfSelectedRecipientPersonAliasId.ValueAsInt();
-            SendMessage( toPersonAliasId, message, false );
+
+            int? toPersonId = new PersonAliasService( new RockContext() ).GetPersonId( toPersonAliasId );
+            if ( !toPersonId.HasValue )
+            {
+                return;
+            }
+
+            SendMessageToPerson( toPersonId.Value, message, false );
             tbNewMessage.Text = string.Empty;
-            LoadResponsesForRecipient( toPersonAliasId );
+            LoadResponsesForRecipientPerson( toPersonId.Value );
             UpdateMessagePart( message );
         }
 
@@ -592,16 +674,16 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
 
             nbNoSms.Visible = false;
 
-            int toPersonAliasId = ppRecipient.PersonAliasId.Value;
-            var personAliasService = new PersonAliasService( new RockContext() );
-            var toPerson = personAliasService.GetPerson( toPersonAliasId );
-            if ( !toPerson.PhoneNumbers.Where( p => p.IsMessagingEnabled ).Any() )
+            int toPersonId = ppRecipient.PersonId.Value;
+            var personService = new PersonService( new RockContext() );
+            var personHasSMSNumbers = personService.GetSelect( toPersonId, s => s.PhoneNumbers.Where( a => a.IsMessagingEnabled ).Any() );
+            if ( !personHasSMSNumbers )
             {
                 nbNoSms.Visible = true;
                 return;
             }
 
-            SendMessage( toPersonAliasId, message, true );
+            SendMessageToPerson( toPersonId, message, true );
 
             mdNewMessage.Hide();
             LoadResponseListing();
@@ -657,8 +739,13 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 recipientPerson = new PersonAliasService( rockContext ).GetPerson( recipientPersonAliasId.Value );
             }
 
+            if ( recipientPerson == null )
+            {
+                return;
+            }
+
             noteEditor.Visible = false;
-            var messagePart = LoadResponsesForRecipient( recipientPersonAliasId.Value );
+            var messagePart = LoadResponsesForRecipientPerson( recipientPerson.Id );
             if ( messagePart == "Rock-Image-File" )
             {
                 litMessagePart.Text = "Image";
@@ -673,7 +760,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
 
             if ( smsPhoneDefinedValueId.HasValue && recipientPersonAliasId.HasValue )
             {
-                new CommunicationResponseService( rockContext ).UpdateReadPropertyByFromPersonAliasId( recipientPersonAliasId.Value, smsPhoneDefinedValueId.Value );
+                new CommunicationResponseService( rockContext ).UpdateReadPropertyByFromPersonId( recipientPerson.Id, smsPhoneDefinedValueId.Value );
             }
 
             tbNewMessage.Visible = true;
@@ -741,7 +828,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             litDateTime.Text = responseListItem.HumanizedCreatedDateTime;
             litMessagePart.Text = responseListItem.SMSMessage;
 
-            if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.BinaryFileGuids != null && responseListItem.BinaryFileGuids.Any() )
+            if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.HasAttachments( new RockContext() ) )
             {
                 litMessagePart.Text = "Image";
                 e.Row.AddCssClass( "latest-message-is-image" );
@@ -764,8 +851,8 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
 
             if ( communicationRecipientResponse != null )
             {
-                var hfCommunicationRecipientId = ( HiddenFieldWithClass ) e.Item.FindControl( "hfCommunicationRecipientId" );
-                hfCommunicationRecipientId.Value = communicationRecipientResponse.RecipientPersonAliasId.ToString();
+                var hfCommunicationRecipientPersonAliasId = ( HiddenFieldWithClass ) e.Item.FindControl( "hfCommunicationRecipientPersonAliasId" );
+                hfCommunicationRecipientPersonAliasId.Value = communicationRecipientResponse.RecipientPersonAliasId.ToString();
 
                 var hfCommunicationMessageKey = ( HiddenFieldWithClass ) e.Item.FindControl( "hfCommunicationMessageKey" );
                 hfCommunicationMessageKey.Value = communicationRecipientResponse.MessageKey;
@@ -781,12 +868,14 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                     lSMSMessage.Text = communicationRecipientResponse.SMSMessage;
                 }
 
-                if ( communicationRecipientResponse.BinaryFileGuids != null )
+                var rockContext = new RockContext();
+
+                if ( communicationRecipientResponse.HasAttachments( rockContext ) )
                 {
                     var lSMSAttachments = ( Literal ) e.Item.FindControl( "lSMSAttachments" );
                     string applicationRoot = GlobalAttributesCache.Value( "PublicApplicationRoot" );
 
-                    foreach ( var binaryFileGuid in communicationRecipientResponse.BinaryFileGuids )
+                    foreach ( var binaryFileGuid in communicationRecipientResponse.GetBinaryFileGuids( rockContext ) )
                     {
                         // Show the image thumbnail by appending the html to lSMSMessage.Text
                         string imageElement = $"<a href='{applicationRoot}GetImage.ashx?guid={binaryFileGuid}' target='_blank' rel='noopener noreferrer'><img src='{applicationRoot}GetImage.ashx?guid={binaryFileGuid}&width=200' class='img-responsive sms-image'></a>";
@@ -989,7 +1078,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 EntityId = selectedPersonId,
                 CreatedByPersonAlias = this.CurrentPersonAlias
             };
-            
+
             noteEditor.SetNote( note );
         }
 

--- a/Communication/SmsConversations.ascx.cs
+++ b/Communication/SmsConversations.ascx.cs
@@ -13,6 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+//
+// <notice>
+// This file contains modifications by Kingdom First Solutions
+// and is a derivative work.
+//
+// Modification (including but not limited to):
+// * Add a checkbox to toggle showing inbound texts only.
+// * v13.4+ only.
+// </notice>
+//
 
 using System;
 using System.Collections.Generic;

--- a/Communication/SmsConversations.ascx.cs
+++ b/Communication/SmsConversations.ascx.cs
@@ -1,0 +1,1009 @@
+﻿// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Linq;
+using System.Web.UI.HtmlControls;
+using System.Web.UI.WebControls;
+
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Model;
+using Rock.Security;
+using Rock.Web.Cache;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace RockWeb.Plugins.rocks_kfs.Communication
+{
+    [DisplayName( "SMS Conversations" )]
+    [Category( "KFS > Communication" )]
+    [Description( "Block for having SMS Conversations between an SMS enabled phone and a Rock SMS Phone number that has 'Enable Mobile Conversations' set to false." )]
+    [DefinedValueField( "Allowed SMS Numbers",
+        Key = AttributeKey.AllowedSMSNumbers,
+        DefinedTypeGuid = Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM,
+        Description = "Set the allowed FROM numbers to appear when in SMS mode (if none are selected all numbers will be included). ",
+        IsRequired = false,
+        AllowMultiple = true,
+        Order = 1 )]
+
+    [BooleanField( "Show only personal SMS number",
+        Key = AttributeKey.ShowOnlyPersonalSmsNumber,
+        Description = "Only SMS Numbers tied to the current individual will be shown. Those with ADMIN rights will see all SMS Numbers.",
+        DefaultBooleanValue = false,
+        Order = 2
+         )]
+
+    [BooleanField( "Hide personal SMS numbers",
+        Key = AttributeKey.HidePersonalSmsNumbers,
+        Description = "Only SMS Numbers that are not associated with a person. The numbers without a 'ResponseRecipient' attribute value.",
+        DefaultBooleanValue = false,
+        Order = 3
+         )]
+
+    [BooleanField( "Enable SMS Send",
+        Key = AttributeKey.EnableSmsSend,
+        Description = "Allow SMS messages to be sent from the block.",
+        DefaultBooleanValue = true,
+        Order = 4
+         )]
+
+    [IntegerField( "Show Conversations From Months Ago",
+        Key = AttributeKey.ShowConversationsFromMonthsAgo,
+        Description = "Limits the conversations shown in the left pane to those of X months ago or newer. This does not affect the actual messages shown on the right.",
+        DefaultIntegerValue = 6,
+        Order = 5
+         )]
+
+    [IntegerField( "Max Conversations",
+        Key = AttributeKey.MaxConversations,
+        Description = "Limits the number of conversations shown in the left pane. This does not affect the actual messages shown on the right.",
+        DefaultIntegerValue = 100,
+        Order = 5
+         )]
+
+    [CodeEditorField( "Person Info Lava Template",
+        Key = AttributeKey.PersonInfoLavaTemplate,
+        Description = "A Lava template to display person information about the selected Communication Recipient.",
+        DefaultValue = "{{ Person.FullName }}",
+        EditorMode = CodeEditorMode.Lava,
+        EditorTheme = CodeEditorTheme.Rock,
+        EditorHeight = 300,
+        IsRequired = false,
+        Order = 6
+         )]
+
+    [NoteTypeField( "Note Types",
+        Description = "Optional list of note types to limit the note editor to.",
+        AllowMultiple = true,
+        IsRequired = false,
+        EntityType = typeof( Rock.Model.Person ),
+        Order = 7,
+        Key = AttributeKey.NoteTypes )]
+
+    public partial class SmsConversations : RockBlock
+    {
+        #region Attribute Keys
+        protected static class AttributeKey
+        {
+            public const string AllowedSMSNumbers = "AllowedSMSNumbers";
+            public const string ShowOnlyPersonalSmsNumber = "ShowOnlyPersonalSmsNumber";
+            public const string HidePersonalSmsNumbers = "HidePersonalSmsNumbers";
+            public const string EnableSmsSend = "EnableSmsSend";
+            public const string ShowConversationsFromMonthsAgo = "ShowConversationsFromMonthsAgo";
+            public const string MaxConversations = "MaxConversations";
+            public const string PersonInfoLavaTemplate = "PersonInfoLavaTemplate";
+            public const string NoteTypes = "NoteTypes";
+        }
+
+        #endregion Attribute Keys
+
+        #region Control Overrides
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            newPersonEditor.ShowEmail = false;
+
+            HtmlMeta preventPhoneMetaTag = new HtmlMeta
+            {
+                Name = "format-detection",
+                Content = "telephone=no"
+            };
+
+            RockPage.AddMetaTag( this.Page, preventPhoneMetaTag );
+
+            this.BlockUpdated += Block_BlockUpdated;
+            noteEditor.SaveButtonClick += noteEditor_SaveButtonClick;
+            ConfigureNoteEditor();
+
+            btnCreateNewMessage.Visible = this.GetAttributeValue( AttributeKey.EnableSmsSend ).AsBoolean();
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            string postbackArgs = Request.Params["__EVENTARGUMENT"] ?? string.Empty;
+
+            nbAddPerson.Visible = false;
+
+            if ( ppPersonFilter.PersonId != null )
+            {
+                divPersonFilter.Style.Remove( "display" );
+            }
+
+            if ( !IsPostBack )
+            {
+                if ( LoadPhoneNumbers() )
+                {
+                    nbNoNumbers.Visible = false;
+                    divMain.Visible = true;
+                    LoadResponseListing();
+                }
+                else
+                {
+                    nbNoNumbers.Visible = true;
+                    divMain.Visible = false;
+                }
+            }
+        }
+
+        #endregion Control Overrides
+
+        #region private/protected Methods
+
+        /// <summary>
+        /// Loads the phone numbers.
+        /// </summary>
+        /// <returns></returns>
+        private bool LoadPhoneNumbers()
+        {
+            // First load up all of the available numbers
+            var smsNumbers = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.COMMUNICATION_SMS_FROM.AsGuid() ).DefinedValues.Where( a => a.IsAuthorized( Rock.Security.Authorization.VIEW, CurrentPerson ) );
+
+            var selectedNumberGuids = GetAttributeValue( AttributeKey.AllowedSMSNumbers ).SplitDelimitedValues( true ).AsGuidList();
+            if ( selectedNumberGuids.Any() )
+            {
+                smsNumbers = smsNumbers.Where( v => selectedNumberGuids.Contains( v.Guid ) ).ToList();
+            }
+
+            // filter personal numbers (any that have a response recipient) if the hide personal option is enabled
+            if ( GetAttributeValue( AttributeKey.HidePersonalSmsNumbers ).AsBoolean() )
+            {
+                smsNumbers = smsNumbers.Where( v => v.GetAttributeValue( "ResponseRecipient" ).IsNullOrWhiteSpace() ).ToList();
+            }
+
+            // Show only numbers 'tied to the current' individual...unless they have 'Admin rights'.
+            if ( GetAttributeValue( AttributeKey.ShowOnlyPersonalSmsNumber ).AsBoolean() && !IsUserAuthorized( Authorization.ADMINISTRATE ) )
+            {
+                smsNumbers = smsNumbers.Where( v => CurrentPerson.Aliases.Any( a => a.Guid == v.GetAttributeValue( "ResponseRecipient" ).AsGuid() ) ).ToList();
+            }
+
+            if ( smsNumbers.Any() )
+            {
+                var smsDetails = smsNumbers.Select( v => new
+                {
+                    v.Id,
+                    Description = string.IsNullOrWhiteSpace( v.Description )
+                    ? PhoneNumber.FormattedNumber( string.Empty, v.Value.Replace( "+", string.Empty ) )
+                    : v.Description.LeftWithEllipsis( 25 ),
+                } );
+
+                ddlSmsNumbers.DataSource = smsDetails;
+                ddlSmsNumbers.Visible = smsNumbers.Count() > 1;
+                ddlSmsNumbers.DataValueField = "Id";
+                ddlSmsNumbers.DataTextField = "Description";
+                ddlSmsNumbers.DataBind();
+
+                string keyPrefix = string.Format( "sms-conversations-{0}-", this.BlockId );
+
+                string smsNumberUserPref = this.GetUserPreference( keyPrefix + "smsNumber" ) ?? string.Empty;
+
+                if ( smsNumberUserPref.IsNotNullOrWhiteSpace() )
+                {
+                    // Don't try to set the selected value unless you are sure it's in the list of items.
+                    if ( ddlSmsNumbers.Items.FindByValue( smsNumberUserPref ) != null )
+                    {
+                        ddlSmsNumbers.SelectedValue = smsNumberUserPref;
+                    }
+                }
+
+                hlSmsNumber.Visible = smsNumbers.Count() == 1;
+                hlSmsNumber.Text = smsDetails.Select( v => v.Description ).FirstOrDefault();
+                hfSmsNumber.SetValue( smsNumbers.Count() > 1 ? ddlSmsNumbers.SelectedValue.AsInteger() : smsDetails.Select( v => v.Id ).FirstOrDefault() );
+
+                tglShowRead.Checked = this.GetUserPreference( keyPrefix + "showRead" ).AsBooleanOrNull() ?? true;
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private void LoadResponseListing()
+        {
+            LoadResponseListing( null );
+        }
+
+        /// <summary>
+        /// Loads the response listing.
+        /// </summary>
+        private void LoadResponseListing( int? personId )
+        {
+            // NOTE: The FromPersonAliasId is the person who sent a text from a mobile device to Rock.
+            // This person is also referred to as the Recipient because they are responding to a
+            // communication from Rock. Restated the response is from the recipient of a communication.
+
+            // This is the person lava field, we want to clear it because reloading this list will deselect the user.
+            litSelectedRecipientDescription.Text = string.Empty;
+            hfSelectedRecipientPersonAliasId.Value = string.Empty;
+            hfSelectedMessageKey.Value = string.Empty;
+            tbNewMessage.Visible = false;
+            btnSend.Visible = false;
+            btnEditNote.Visible = false;
+            lbShowImagePicker.Visible = false;
+            noteEditor.Visible = false;
+
+            int? smsPhoneDefinedValueId = hfSmsNumber.ValueAsInt();
+            if ( smsPhoneDefinedValueId == default( int ) )
+            {
+                return;
+            }
+
+            using ( var rockContext = new RockContext() )
+            {
+                var communicationResponseService = new CommunicationResponseService( rockContext );
+
+                int months = GetAttributeValue( AttributeKey.ShowConversationsFromMonthsAgo ).AsInteger();
+
+                var startDateTime = RockDateTime.Now.AddMonths( -months );
+                bool showRead = tglShowRead.Checked;
+
+                var maxConversations = this.GetAttributeValue( AttributeKey.MaxConversations ).AsIntegerOrNull() ?? 1000;
+
+                var responseListItems = communicationResponseService.GetCommunicationResponseRecipients( smsPhoneDefinedValueId.Value, startDateTime, showRead, maxConversations, personId );
+
+                // don't display conversations if we're rebinding the recipient list
+                rptConversation.Visible = false;
+                gRecipients.DataSource = responseListItems;
+                gRecipients.DataBind();
+            }
+        }
+
+        /// <summary>
+        /// Loads the responses for recipient.
+        /// </summary>
+        /// <param name="recipientPersonAliasId">The recipient person alias identifier.</param>
+        /// <returns></returns>
+        private string LoadResponsesForRecipient( int recipientPersonAliasId )
+        {
+            int? smsPhoneDefinedValueId = hfSmsNumber.ValueAsInt();
+
+            if ( smsPhoneDefinedValueId == default( int ) )
+            {
+                return string.Empty;
+            }
+
+            var communicationResponseService = new CommunicationResponseService( new RockContext() );
+            List<CommunicationRecipientResponse> responses = communicationResponseService.GetCommunicationConversation( recipientPersonAliasId, smsPhoneDefinedValueId.Value );
+
+            BindConversationRepeater( responses );
+
+            if ( responses.Any() )
+            {
+                var responseListItem = responses.Last();
+
+                if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.BinaryFileGuids != null && responseListItem.BinaryFileGuids.Any() )
+                {
+                    return "Rock-Image-File";
+                }
+
+                return responses.Last().SMSMessage;
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Binds the conversation repeater.
+        /// </summary>
+        /// <param name="responses">The responses.</param>
+        private void BindConversationRepeater( List<CommunicationRecipientResponse> responses )
+        {
+            rptConversation.Visible = true;
+            rptConversation.DataSource = responses;
+            rptConversation.DataBind();
+        }
+
+        /// <summary>
+        /// Populates the person lava.
+        /// </summary>
+        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
+        private void PopulatePersonLava( RowEventArgs e )
+        {
+            var hfRecipientPersonAliasId = ( HiddenField ) e.Row.FindControl( "hfRecipientPersonAliasId" );
+            int? recipientPersonAliasId = hfSelectedRecipientPersonAliasId.Value.AsIntegerOrNull();
+
+            var hfMessageKey = ( HiddenField ) e.Row.FindControl( "hfMessageKey" );
+            var lblName = ( Label ) e.Row.FindControl( "lblName" );
+            string html = lblName.Text;
+            string unknownPerson = " (Unknown Person)";
+            var lava = GetAttributeValue( AttributeKey.PersonInfoLavaTemplate );
+
+            if ( !recipientPersonAliasId.HasValue || recipientPersonAliasId.Value == -1 )
+            {
+                // We don't have a person to do the lava merge so just display the formatted phone number
+                html = PhoneNumber.FormattedNumber( string.Empty, hfMessageKey.Value ) + unknownPerson;
+                litSelectedRecipientDescription.Text = html;
+            }
+            else
+            {
+                // Merge the person and lava
+                using ( var rockContext = new RockContext() )
+                {
+                    var personAliasService = new PersonAliasService( rockContext );
+                    var recipientPerson = personAliasService.GetPerson( recipientPersonAliasId.Value );
+                    var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( RockPage, CurrentPerson );
+                    mergeFields.Add( "Person", recipientPerson );
+
+                    html = lava.ResolveMergeFields( mergeFields );
+                }
+            }
+
+            litSelectedRecipientDescription.Text = string.Format( "<div class='header-lava pull-left'>{0}</div>", html );
+        }
+
+        /// <summary>
+        /// Saves the settings.
+        /// </summary>
+        private void SaveSettings()
+        {
+            string keyPrefix = string.Format( "sms-conversations-{0}-", this.BlockId );
+
+            if ( ddlSmsNumbers.Visible )
+            {
+                this.SetUserPreference( keyPrefix + "smsNumber", ddlSmsNumbers.SelectedValue.ToString() );
+                hfSmsNumber.SetValue( ddlSmsNumbers.SelectedValue.AsInteger() );
+            }
+            else
+            {
+                this.SetUserPreference( keyPrefix + "smsNumber", hfSmsNumber.Value.ToString() );
+            }
+
+            this.SetUserPreference( keyPrefix + "showRead", tglShowRead.Checked.ToString() );
+        }
+
+        /// <summary>
+        /// Sends the message.
+        /// </summary>
+        /// <param name="toPersonAliasId">To person alias identifier.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="newMessage">if set to <c>true</c> [new message].</param>
+        private void SendMessage( int toPersonAliasId, string message, bool newMessage )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                // The sender is the logged in user.
+                int fromPersonAliasId = CurrentUser.Person.PrimaryAliasId.Value;
+                string fromPersonName = CurrentUser.Person.FullName;
+
+                // The sending phone is the selected one
+                DefinedValueCache fromPhone = DefinedValueCache.Get( hfSmsNumber.ValueAsInt() );
+
+                string responseCode = Rock.Communication.Medium.Sms.GenerateResponseCode( rockContext );
+
+                BinaryFile binaryFile = null;
+                List<BinaryFile> photos = null;
+
+                if ( !newMessage && ImageUploaderConversation.BinaryFileId.IsNotNullOrZero() )
+                {
+                    // If this is a response using the conversation window and a photo file has been uploaded then add it
+                    binaryFile = new BinaryFileService( rockContext ).Get( ImageUploaderConversation.BinaryFileId.Value );
+                }
+                else if ( newMessage && ImageUploaderModal.BinaryFileId.IsNotNullOrZero() )
+                {
+                    // If this is a new message using the modal and a photo file has been uploaded then add it
+                    binaryFile = new BinaryFileService( rockContext ).Get( ImageUploaderModal.BinaryFileId.Value );
+                }
+
+                photos = binaryFile.IsNotNull() ? new List<BinaryFile> { binaryFile } : null;
+
+                // Create and enqueue the communication
+                Rock.Communication.Medium.Sms.CreateCommunicationMobile( CurrentUser.Person, toPersonAliasId, message, fromPhone, responseCode, rockContext, photos );
+                ImageUploaderConversation.BinaryFileId = null;
+            }
+        }
+
+        /// <summary>
+        /// Updates the message part for the grid row with the selected message key with the provided message string.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        private void UpdateMessagePart( string message )
+        {
+            foreach ( GridViewRow row in gRecipients.Rows )
+            {
+                if ( row.RowType != DataControlRowType.DataRow )
+                {
+                    continue;
+                }
+
+                var messageKeyHiddenField = ( HiddenFieldWithClass ) row.FindControl( "hfMessageKey" );
+                if ( messageKeyHiddenField.Value == hfSelectedMessageKey.Value )
+                {
+                    Literal literal = ( Literal ) row.FindControl( "litMessagePart" );
+
+                    // This is our row, update the lit
+                    if ( message == "Rock-Image-File" )
+                    {
+                        literal.Text = "Image";
+                        row.AddCssClass( "latest-message-is-image" );
+                    }
+                    else
+                    {
+                        literal.Text = message;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        #endregion private/protected Methods
+
+        #region Control Events
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            this.NavigateToCurrentPageReference();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the lbLinkConversation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbLinkConversation_Click( object sender, EventArgs e )
+        {
+            mdLinkToPerson.Title = string.Format( "Link Phone Number {0} to Person ", PhoneNumber.FormattedNumber( PhoneNumber.DefaultCountryCode(), hfSelectedMessageKey.Value, false ) );
+            ppPerson.SetValue( null );
+            newPersonEditor.SetFromPerson( null );
+            mdLinkToPerson.Show();
+        }
+
+        /// <summary>
+        /// Handles the SelectedIndexChanged event of the ddlSmsNumbers control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ddlSmsNumbers_SelectedIndexChanged( object sender, EventArgs e )
+        {
+            SaveSettings();
+            LoadResponseListing();
+        }
+
+        /// <summary>
+        /// Handles the CheckedChanged event of the tglShowRead control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void tglShowRead_CheckedChanged( object sender, EventArgs e )
+        {
+            SaveSettings();
+            LoadResponseListing();
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnCreateNewMessage control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnCreateNewMessage_Click( object sender, EventArgs e )
+        {
+            lblMdNewMessageSendingSMSNumber.Text = ddlSmsNumbers.SelectedItem.Text;
+            mdNewMessage.Show();
+        }
+
+        /// <summary>
+        /// Handles the SelectPerson event of the ppPersonFilter control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ppPersonFilter_SelectPerson( object sender, EventArgs e )
+        {
+            if ( ppPersonFilter.PersonId != null )
+            {
+                lbPersonFilter.AddCssClass( "bg-warning" );
+            }
+            else
+            {
+                lbPersonFilter.RemoveCssClass( "bg-warning" );
+            }
+
+            LoadResponseListing( ppPersonFilter.PersonId );
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnSend control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnSend_Click( object sender, EventArgs e )
+        {
+            string message = tbNewMessage.Text.Trim();
+
+            if ( hfSelectedRecipientPersonAliasId.Value == string.Empty || ( message.Length == 0 && ImageUploaderConversation.BinaryFileId.IsNullOrZero() ) )
+            {
+                return;
+            }
+
+            int toPersonAliasId = hfSelectedRecipientPersonAliasId.ValueAsInt();
+            SendMessage( toPersonAliasId, message, false );
+            tbNewMessage.Text = string.Empty;
+            LoadResponsesForRecipient( toPersonAliasId );
+            UpdateMessagePart( message );
+        }
+
+        /// <summary>
+        /// Handles the SaveClick event of the mdNewMessage control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void mdNewMessage_SaveClick( object sender, EventArgs e )
+        {
+            string message = tbSMSTextMessage.Text.Trim();
+            if ( message.IsNullOrWhiteSpace() )
+            {
+                return;
+            }
+
+            nbNoSms.Visible = false;
+
+            int toPersonAliasId = ppRecipient.PersonAliasId.Value;
+            var personAliasService = new PersonAliasService( new RockContext() );
+            var toPerson = personAliasService.GetPerson( toPersonAliasId );
+            if ( !toPerson.PhoneNumbers.Where( p => p.IsMessagingEnabled ).Any() )
+            {
+                nbNoSms.Visible = true;
+                return;
+            }
+
+            SendMessage( toPersonAliasId, message, true );
+
+            mdNewMessage.Hide();
+            LoadResponseListing();
+        }
+
+        /// <summary>
+        /// Handles the SelectPerson event of the ppRecipient control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void ppRecipient_SelectPerson( object sender, EventArgs e )
+        {
+            nbNoSms.Visible = false;
+
+            int toPersonAliasId = ppRecipient.PersonAliasId.Value;
+            var personAliasService = new PersonAliasService( new RockContext() );
+            var toPerson = personAliasService.GetPerson( toPersonAliasId );
+            if ( !toPerson.PhoneNumbers.Where( p => p.IsMessagingEnabled ).Any() )
+            {
+                nbNoSms.Visible = true;
+            }
+        }
+
+        /// <summary>
+        /// Handles the RowSelected event of the gRecipients control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
+        protected void gRecipients_RowSelected( object sender, RowEventArgs e )
+        {
+            if ( e.Row.RowType != DataControlRowType.DataRow )
+            {
+                return;
+            }
+
+            var hfRecipientPersonAliasId = ( HiddenField ) e.Row.FindControl( "hfRecipientPersonAliasId" );
+            var hfMessageKey = ( HiddenField ) e.Row.FindControl( "hfMessageKey" );
+
+            // Since we can get newer messages when a selected let's also update the message part on the response recipients grid.
+            var litMessagePart = ( Literal ) e.Row.FindControl( "litMessagePart" );
+
+            int? recipientPersonAliasId = hfRecipientPersonAliasId.Value.AsIntegerOrNull();
+            string messageKey = hfMessageKey.Value;
+
+            hfSelectedRecipientPersonAliasId.Value = recipientPersonAliasId.ToString();
+            hfSelectedMessageKey.Value = hfMessageKey.Value;
+
+            var rockContext = new RockContext();
+
+            Person recipientPerson = null;
+            if ( recipientPersonAliasId.HasValue )
+            {
+                recipientPerson = new PersonAliasService( rockContext ).GetPerson( recipientPersonAliasId.Value );
+            }
+
+            noteEditor.Visible = false;
+            var messagePart = LoadResponsesForRecipient( recipientPersonAliasId.Value );
+            if ( messagePart == "Rock-Image-File" )
+            {
+                litMessagePart.Text = "Image";
+                e.Row.AddCssClass( "latest-message-is-image" );
+            }
+            else
+            {
+                litMessagePart.Text = messagePart;
+            }
+
+            int? smsPhoneDefinedValueId = hfSmsNumber.Value.AsIntegerOrNull();
+
+            if ( smsPhoneDefinedValueId.HasValue && recipientPersonAliasId.HasValue )
+            {
+                new CommunicationResponseService( rockContext ).UpdateReadPropertyByFromPersonAliasId( recipientPersonAliasId.Value, smsPhoneDefinedValueId.Value );
+            }
+
+            tbNewMessage.Visible = true;
+            btnSend.Visible = true;
+            btnEditNote.Visible = true;
+            lbShowImagePicker.Visible = true;
+
+            upConversation.Attributes.Add( "class", "conversation-panel has-focus" );
+
+            foreach ( GridViewRow row in gRecipients.Rows )
+            {
+                row.RemoveCssClass( "selected" );
+            }
+
+            e.Row.AddCssClass( "selected" );
+            e.Row.RemoveCssClass( "unread" );
+
+            // We're checking nameless person first because we don't need to worry about the rest for non-nameless people.
+            var isRecipientPartOfMergeRequest = recipientPerson.IsNameless() && recipientPerson.IsPartOfMergeRequest();
+
+            if ( recipientPerson == null || ( recipientPerson.IsNameless() && !isRecipientPartOfMergeRequest ) )
+            {
+                lbLinkConversation.Visible = true;
+                lbViewMergeRequest.Visible = false;
+            }
+            else
+            {
+                lbLinkConversation.Visible = false;
+                lbViewMergeRequest.Visible = isRecipientPartOfMergeRequest;
+            }
+
+            PopulatePersonLava( e );
+        }
+
+        /// <summary>
+        /// Handles the RowDataBound event of the gRecipients control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
+        protected void gRecipients_RowDataBound( object sender, GridViewRowEventArgs e )
+        {
+            if ( e.Row.RowType != DataControlRowType.DataRow )
+            {
+                return;
+            }
+
+            var hfRecipientPersonAliasId = e.Row.FindControl( "hfRecipientPersonAliasId" ) as HiddenField;
+            var hfMessageKey = e.Row.FindControl( "hfMessageKey" ) as HiddenField;
+            var lblName = e.Row.FindControl( "lblName" ) as Label;
+            var litDateTime = e.Row.FindControl( "litDateTime" ) as Literal;
+            var litMessagePart = e.Row.FindControl( "litMessagePart" ) as Literal;
+
+            var responseListItem = e.Row.DataItem as CommunicationRecipientResponse;
+            hfRecipientPersonAliasId.Value = responseListItem.RecipientPersonAliasId.ToString();
+            hfMessageKey.Value = responseListItem.MessageKey;
+            if ( responseListItem.IsNamelessPerson )
+            {
+                lblName.Text = PhoneNumber.FormattedNumber( null, responseListItem.MessageKey );
+            }
+            else
+            {
+                lblName.Text = responseListItem.FullName;
+            }
+
+            litDateTime.Text = responseListItem.HumanizedCreatedDateTime;
+            litMessagePart.Text = responseListItem.SMSMessage;
+
+            if ( responseListItem.SMSMessage.IsNullOrWhiteSpace() && responseListItem.BinaryFileGuids != null && responseListItem.BinaryFileGuids.Any() )
+            {
+                litMessagePart.Text = "Image";
+                e.Row.AddCssClass( "latest-message-is-image" );
+            }
+
+            if ( !responseListItem.IsRead )
+            {
+                e.Row.AddCssClass( "unread" );
+            }
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the rptConversation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="RepeaterItemEventArgs"/> instance containing the event data.</param>
+        protected void rptConversation_ItemDataBound( object sender, RepeaterItemEventArgs e )
+        {
+            CommunicationRecipientResponse communicationRecipientResponse = e.Item.DataItem as CommunicationRecipientResponse;
+
+            if ( communicationRecipientResponse != null )
+            {
+                var hfCommunicationRecipientId = ( HiddenFieldWithClass ) e.Item.FindControl( "hfCommunicationRecipientId" );
+                hfCommunicationRecipientId.Value = communicationRecipientResponse.RecipientPersonAliasId.ToString();
+
+                var hfCommunicationMessageKey = ( HiddenFieldWithClass ) e.Item.FindControl( "hfCommunicationMessageKey" );
+                hfCommunicationMessageKey.Value = communicationRecipientResponse.MessageKey;
+
+                var lSMSMessage = ( Literal ) e.Item.FindControl( "lSMSMessage" );
+                if ( communicationRecipientResponse.SMSMessage.IsNullOrWhiteSpace() )
+                {
+                    var divCommunicationBody = ( HtmlControl ) e.Item.FindControl( "divCommunicationBody" );
+                    divCommunicationBody.Visible = false;
+                }
+                else
+                {
+                    lSMSMessage.Text = communicationRecipientResponse.SMSMessage;
+                }
+
+                if ( communicationRecipientResponse.BinaryFileGuids != null )
+                {
+                    var lSMSAttachments = ( Literal ) e.Item.FindControl( "lSMSAttachments" );
+                    string applicationRoot = GlobalAttributesCache.Value( "PublicApplicationRoot" );
+
+                    foreach ( var binaryFileGuid in communicationRecipientResponse.BinaryFileGuids )
+                    {
+                        // Show the image thumbnail by appending the html to lSMSMessage.Text
+                        string imageElement = $"<a href='{applicationRoot}GetImage.ashx?guid={binaryFileGuid}' target='_blank' rel='noopener noreferrer'><img src='{applicationRoot}GetImage.ashx?guid={binaryFileGuid}&width=200' class='img-responsive sms-image'></a>";
+
+                        // If there is a text portion or previous image then drop down a line before appending the image element
+                        lSMSAttachments.Text += imageElement;
+                    }
+                }
+
+                var lSenderName = ( Literal ) e.Item.FindControl( "lSenderName" );
+                lSenderName.Text = communicationRecipientResponse.FullName;
+
+                var lblMessageDateTime = ( Label ) e.Item.FindControl( "lblMessageDateTime" );
+                lblMessageDateTime.ToolTip = communicationRecipientResponse.CreatedDateTime.ToString();
+                lblMessageDateTime.Text = communicationRecipientResponse.HumanizedCreatedDateTime.ToString();
+
+                if ( communicationRecipientResponse.MessageStatus == CommunicationRecipientStatus.Pending )
+                {
+                    lblMessageDateTime.Text += " (Pending)";
+                }
+
+                var divCommunication = ( HtmlGenericControl ) e.Item.FindControl( "divCommunication" );
+
+                if ( communicationRecipientResponse.IsOutbound )
+                {
+                    divCommunication.RemoveCssClass( "inbound" );
+                    divCommunication.AddCssClass( "outbound" );
+                }
+                else
+                {
+                    divCommunication.RemoveCssClass( "outbound" );
+                    divCommunication.AddCssClass( "inbound" );
+                }
+            }
+        }
+
+        #endregion Control Events
+
+        #region Link Conversation Modal
+
+        /// <summary>
+        /// Handles the SaveClick event of the mdLinkConversation control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void mdLinkToPerson_SaveClick( object sender, EventArgs e )
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var personAliasService = new PersonAliasService( rockContext );
+                var personService = new PersonService( rockContext );
+
+                // Get the Person Record from the selected conversation. (It should be a 'NamelessPerson' record type)
+                int namelessPersonAliasId = hfSelectedRecipientPersonAliasId.Value.AsInteger();
+                var phoneNumberService = new PhoneNumberService( rockContext );
+                Person namelessPerson = personAliasService.GetPerson( namelessPersonAliasId );
+
+                if ( namelessPerson == null )
+                {
+                    // shouldn't happen, but just in case
+                    return;
+                }
+
+                EntitySet mergeRequest = null;
+                if ( pnlLinkToExistingPerson.Visible )
+                {
+                    var existingPersonId = ppPerson.PersonId;
+                    if ( !existingPersonId.HasValue )
+                    {
+                        return;
+                    }
+
+                    var existingPerson = personService.Get( existingPersonId.Value );
+                    mergeRequest = namelessPerson.CreateMergeRequest( existingPerson );
+                    var entitySetService = new EntitySetService( rockContext );
+                    entitySetService.Add( mergeRequest );
+
+                    rockContext.SaveChanges();
+                    hfSelectedRecipientPersonAliasId.Value = existingPerson.PrimaryAliasId.ToString();
+                }
+                else
+                {
+                    // new Person and new family
+                    var newPerson = new Person();
+
+                    newPersonEditor.UpdatePerson( newPerson, rockContext );
+
+                    personService.Add( newPerson );
+                    rockContext.SaveChanges();
+
+                    mergeRequest = namelessPerson.CreateMergeRequest( newPerson );
+                    var entitySetService = new EntitySetService( rockContext );
+                    entitySetService.Add( mergeRequest );
+                    rockContext.SaveChanges();
+
+                    hfSelectedRecipientPersonAliasId.Value = newPerson.PrimaryAliasId.ToString();
+                }
+
+                RedirectToMergeRequest( mergeRequest );
+
+            }
+
+            mdLinkToPerson.Hide();
+            LoadResponseListing();
+        }
+
+        /// <summary>
+        /// Handles the CheckedChanged event of the tglLinkPersonMode control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void tglLinkPersonMode_CheckedChanged( object sender, EventArgs e )
+        {
+            pnlLinkToExistingPerson.Visible = tglLinkPersonMode.Checked;
+            pnlLinkToNewPerson.Visible = !tglLinkPersonMode.Checked;
+        }
+
+        #endregion Link Conversation Modal
+
+        /// <summary>
+        /// Handles the Click event of the lbViewMergeRequest control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void lbViewMergeRequest_Click( object sender, EventArgs e )
+        {
+            var namelessPersonAliasId = hfSelectedRecipientPersonAliasId.Value.AsInteger();
+
+            using ( var rockContext = new RockContext() )
+            {
+                var personAliasService = new PersonAliasService( rockContext );
+                var namelessPerson = personAliasService.GetPerson( namelessPersonAliasId );
+
+                var mergeRequest = namelessPerson.GetMergeRequest( rockContext );
+
+                RedirectToMergeRequest( mergeRequest );
+            }
+        }
+
+        /// <summary>
+        /// Redirects to merge request.
+        /// </summary>
+        /// <param name="mergeRequest">The merge request.</param>
+        private void RedirectToMergeRequest( EntitySet mergeRequest )
+        {
+            if ( mergeRequest != null )
+            {
+                Page.Response.Redirect( string.Format( "~/PersonMerge/{0}", mergeRequest.Id ), false );
+                Context.ApplicationInstance.CompleteRequest();
+            }
+        }
+
+        #region Edit Note
+
+        /// <summary>
+        /// Configures the note editor.
+        /// </summary>
+        /// <param name="personId">The person identifier.</param>
+        private void ConfigureNoteEditor()
+        {
+            var noteTypes = NoteTypeCache.GetByEntity( EntityTypeCache.GetId<Rock.Model.Person>(), string.Empty, string.Empty, true );
+
+            // If block is configured to only allow certain note types, limit notes to those types.
+            var configuredNoteTypes = GetAttributeValue( AttributeKey.NoteTypes ).SplitDelimitedValues().AsGuidList();
+            if ( configuredNoteTypes.Any() )
+            {
+                noteTypes = noteTypes.Where( n => configuredNoteTypes.Contains( n.Guid ) ).ToList();
+            }
+
+            NoteOptions noteOptions = new NoteOptions( this.ViewState )
+            {
+                NoteTypes = noteTypes.ToArray(),
+                AddAlwaysVisible = true,
+                DisplayType = NoteDisplayType.Full,
+                ShowAlertCheckBox = true,
+                ShowPrivateCheckBox = true,
+                UsePersonIcon = true,
+                ShowSecurityButton = false,
+                ShowCreateDateInput = false,
+            };
+
+            noteEditor.SetNoteOptions( noteOptions );
+            noteEditor.NoteTypeId = noteTypes.FirstOrDefault()?.Id;
+        }
+
+        /// <summary>
+        /// Handles the Click event of the btnEditNote control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void btnEditNote_Click( object sender, EventArgs e )
+        {
+            noteEditor.Style.Remove( "display" );
+            noteEditor.Visible = true;
+            noteEditor.ShowEditMode = true;
+
+            var selectedPersonId = new PersonAliasService( new RockContext() ).GetPersonId( hfSelectedRecipientPersonAliasId.Value.AsInteger() );
+            var note = new Note
+            {
+                EntityId = selectedPersonId,
+                CreatedByPersonAlias = this.CurrentPersonAlias
+            };
+            
+            noteEditor.SetNote( note );
+        }
+
+        /// <summary>
+        /// Handles the SaveButtonClick event of the noteEditor control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="NoteEventArgs"/> instance containing the event data.</param>
+        private void noteEditor_SaveButtonClick( object sender, NoteEventArgs e )
+        {
+            noteEditor.Visible = false;
+            noteEditor.ShowEditMode = false;
+        }
+
+        #endregion Edit Note
+    }
+}

--- a/Communication/SmsConversations.ascx.cs
+++ b/Communication/SmsConversations.ascx.cs
@@ -642,6 +642,8 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 lbPersonFilter.RemoveCssClass( "bg-warning" );
             }
 
+            cbShowInbound.Checked = false;
+
             LoadResponseListing( ppPersonFilter.PersonId );
         }
 

--- a/Communication/SmsConversations.ascx.cs
+++ b/Communication/SmsConversations.ascx.cs
@@ -317,6 +317,10 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                     var maxConversations = this.GetAttributeValue( AttributeKey.MaxConversations ).AsIntegerOrNull() ?? 1000;
 
                     var responseListItems = communicationResponseService.GetCommunicationResponseRecipients( smsPhoneDefinedValueId.Value, startDateTime, showRead, maxConversations, personId );
+                    if ( cbShowInbound.Checked )
+                    {
+                        responseListItems = responseListItems.Where( r => !r.IsOutbound ).ToList();
+                    }
 
                     // don't display conversations if we're rebinding the recipient list
                     rptConversation.Visible = false;
@@ -629,6 +633,16 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             }
 
             LoadResponseListing( ppPersonFilter.PersonId );
+        }
+
+        /// <summary>
+        /// Handles the CheckedChange event of the cbShowInbound control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void cbShowInbound_CheckedChanged( object sender, EventArgs e )
+        {
+            LoadResponseListing();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Brought in core SMS Conversations block and added a new checkbox to be able to filter down to just inbound text messages.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added a new checkbox to be able to filter down to just inbound text messages.

---------

### Requested By

##### Who reported, requested, or paid for the change?

CBC Neenah

---------

### Screenshots

##### Does this update or add options to the block UI?

<img width="290" alt="image" src="https://user-images.githubusercontent.com/2990519/184175295-874d9e6e-69cb-41cb-bed9-4dace57ae484.png">

---------

### Change Log

##### What files does it affect?

- Communication/SmsConversations.ascx
- Communication/SmsConversations.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
