### PR TITLE
Steps to Care - Index out of Range Fix

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1608,10 +1608,10 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                         var valSplit = hideFilter.Value.SplitDelimitedValues();
                         foreach ( var hideVal in valSplit )
                         {
-                            cssStyle.AppendFormat( "[id*=\"{0}\"] [value=\"{1}\"], [id*=\"{0}\"] [value=\"{1}\"] + span, ", hideFilter.Key, hideVal.EscapeQuotes() );
+                            cssStyle.AppendFormat( "[id*=\"{0}\"][value=\"{1}\"], [id*=\"{0}\"][value=\"{1}\"] + span, ", hideFilter.Key, hideVal.EscapeQuotes() );
                         }
                     }
-                    cssStyle.Append( " .hideSpecificValue { display: none; visibility: hidden; }" );
+                    cssStyle.Append( " .hideSpecificValue { visibility: hidden !important; display: none !important; }" );
                     cssStyle.AppendLine( ".field-criteria .in-columns, .field-criteria .checkbox-inline { margin-top: 0px; }" );
                     cssStyle.AppendLine( ".radio input[type=\"radio\"], .radio-inline input[type=\"radio\"], .checkbox input[type=\"checkbox\"], .checkbox-inline input[type=\"checkbox\"] { top: 50%; transform: translateY(-50%); }" );
                     cssStyle.AppendLine( ".in-columns .label-text { margin-top: 8px }" );

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -930,13 +930,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     }
                     if ( actionsColumn.Visible )
                     {
-                        var actionsCell = e.Row.Cells[gList.Columns.IndexOf( actionsColumn )];
-                        actionsCell.CssClass += " align-middle";
-
+                        TableCell actionsCell = null;
                         if ( followUpGrid )
                         {
                             actionsCell = e.Row.Cells[gFollowUp.Columns.IndexOf( actionsColumn )];
                         }
+                        else
+                        {
+                            actionsCell = e.Row.Cells[gList.Columns.IndexOf( actionsColumn )];
+                        }
+                        actionsCell.CssClass += " align-middle";
 
                         var ddlNav = new HtmlGenericControl( "div" );
                         ddlNav.Attributes["class"] = "btn-group";


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for index out of range error when a worker is assigned to a child need but not the parent need and it goes into the follow up grid. Also snuck in a group finder fix for not always hiding attribute values depending on styles, especially in v14, need to mark as !important to hide.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an index out of range error when a need is in the follow up grid in a specific scenario.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx.cs
- Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No