### PR TITLE
Steps to Care - Workers Only Fix

### DIFF
--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -490,7 +490,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     }
                     if ( isNew && dateDifference <= futureThresholdDays )
                     {
-                        CareUtilities.AutoAssignWorkers( careNeed, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
+                        CareUtilities.AutoAssignWorkers( careNeed, careNeed.WorkersOnly, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                     }
 
                     if ( childNeedsCreated && careNeed.ChildNeeds != null && careNeed.ChildNeeds.Any() && dateDifference <= futureThresholdDays )
@@ -506,7 +506,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             else
                             {
                                 var adultFamilyWorkers = GetAttributeValue( AttributeKey.AdultFamilyWorkers );
-                                CareUtilities.AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only", autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
+                                CareUtilities.AutoAssignWorkers( need, adultFamilyWorkers == "Workers Only" || careNeed.WorkersOnly, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuid: leaderRoleGuid );
                             }
                         }
                     }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Round robin assignment only (Care Workers) when "Workers only" is checked.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed issue when "Workers Only" is selected only workers should be assigned through the round robin assignment, no small group leaders or "geofence"/deacon workers.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

StepsToCare/CareEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
