### PR TITLE
Group Finder Postal Code Protection

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1967,7 +1967,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                             }
                             catch
                             {
-                                ShowWarning( $"An invalid {tbPostalCode.Label} was provided. If {tbPostalCode.Label} is required it will be reset to the default location." );
+                                ShowWarning( $"{tbPostalCode.Text} is an invalid {tbPostalCode.Label}. If {tbPostalCode.Label} is required, it will be reset to the default location." );
                             } // handle invalid postal codes by leaving mapCoordinate null and reverting to default location.
                         }
                     }

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1967,7 +1967,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                             }
                             catch
                             {
-                                ShowWarning( "An invalid Postal Code was provided. If postal code is required it will be reset to the default location." );
+                                ShowWarning( $"An invalid {tbPostalCode.Label} was provided. If {tbPostalCode.Label} is required it will be reset to the default location." );
                             } // handle invalid postal codes by leaving mapCoordinate null and reverting to default location.
                         }
                     }

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1961,10 +1961,14 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                         if ( !string.IsNullOrWhiteSpace( tbPostalCode.Text ) )
                         {
                             try
-                            { 
+                            {
                                 mapCoordinate = new LocationService( rockContext )
                                     .GetMapCoordinateFromPostalCode( tbPostalCode.Text );
-                            } catch { } // handle invalid postal codes by leaving mapCoordinate null
+                            }
+                            catch
+                            {
+                                ShowWarning( "An invalid Postal Code was provided. If postal code is required it will be reset to the default location." );
+                            } // handle invalid postal codes by leaving mapCoordinate null and reverting to default location.
                         }
                     }
                     else

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -31,6 +31,7 @@
 // * Added Keyword search to search name or description of groups
 // * Added an additional setting to include Pending members in Over Capacity checking
 // * Added a setting to override groups Is Public setting to show on the finder.
+// Package Version 1.5
 // </notice>
 //
 using System;
@@ -1959,8 +1960,11 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     {
                         if ( !string.IsNullOrWhiteSpace( tbPostalCode.Text ) )
                         {
-                            mapCoordinate = new LocationService( rockContext )
-                                .GetMapCoordinateFromPostalCode( tbPostalCode.Text );
+                            try
+                            { 
+                                mapCoordinate = new LocationService( rockContext )
+                                    .GetMapCoordinateFromPostalCode( tbPostalCode.Text );
+                            } catch { } // handle invalid postal codes by leaving mapCoordinate null
                         }
                     }
                     else


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add try catch around smarty street method that can return a 500 error when an invalid postal code is provided.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added protection for possible server error if an invalid postal code is provided.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Venture/Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://user-images.githubusercontent.com/2990519/211683030-af58f3f4-ea52-44dd-92c0-f0de60cf6450.png)

---------

### Change Log

##### What files does it affect?

Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
