### PR TITLE
Vimeo Sync All Fix

### DIFF
--- a/Vimeo/ContentChannelItemVimeoSyncAll.ascx.cs
+++ b/Vimeo/ContentChannelItemVimeoSyncAll.ascx.cs
@@ -276,7 +276,7 @@ namespace RockWeb.Plugins.rocks_kfs.Vimeo
 
                     if ( completed % _batchSize < 1 )
                     {
-                        SaveContentChannelItems( contentChannelItems );
+                        SaveContentChannelItems( contentChannelItems, lookupContext );
                         contentChannelItems.Clear();
                     }
                 }
@@ -285,14 +285,17 @@ namespace RockWeb.Plugins.rocks_kfs.Vimeo
             // Save leftovers
             if ( contentChannelItems.Any() )
             {
-                SaveContentChannelItems( contentChannelItems );
+                SaveContentChannelItems( contentChannelItems, lookupContext );
                 contentChannelItems.Clear();
             }
         }
 
-        private void SaveContentChannelItems( List<ContentChannelItem> contentChannelItems )
+        private void SaveContentChannelItems( List<ContentChannelItem> contentChannelItems, RockContext rockContext = null )
         {
-            var rockContext = new RockContext();
+            if ( rockContext == null )
+            {
+                rockContext = new RockContext();
+            }
             rockContext.WrapTransaction( () =>
             {
                 rockContext.SaveChanges();


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fix for Vimeo batch saving not saving name or description of items.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed Vimeo Sync All not saving name or description of items.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Support

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Vimeo/ContentChannelItemVimeoSyncAll.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
