### PR TITLE
Steps to Care Popover Update

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -24,8 +24,12 @@
         overflow-y: auto;
     }
 
-    .popover-content {
+    .js-person-popover-simple + .popover .popover-content {
         text-align: center;
+    }
+
+    .popover-content header img {
+        width: 64px;
     }
 
     .hasParentNeed {
@@ -198,6 +202,44 @@
                     $('.js-person-popover').popover({
                         placement: 'right',
                         trigger: 'manual',
+                        sanitize: false,
+                        delay: 500,
+                        html: true,
+                        content: function ()
+                        {
+                            var dataUrl = Rock.settings.get( 'baseUrl' ) + 'api/People/PopupHtml/' + $( this ).attr( 'personid' ) + '/true';
+
+                            var result = $.ajax( {
+                                type: 'GET',
+                                url: dataUrl,
+                                dataType: 'json',
+                                contentType: 'application/json; charset=utf-8',
+                                async: false
+                            } ).responseText;
+
+                            var resultObject = JSON.parse( result );
+
+                            return resultObject.PickerItemDetailsHtml;
+
+                        }
+                    }).on('mouseenter', function () {
+                        var _this = this;
+                        $(this).popover('show');
+                        $(this).siblings('.popover').on('mouseleave', function () {
+                            $(_this).popover('hide');
+                        });
+                    }).on('mouseleave', function () {
+                        var _this = this;
+                        setTimeout(function () {
+                            if (!$('.popover:hover').length) {
+                                $(_this).popover('hide')
+                            }
+                        }, 100);
+                    } );
+                    $( '.js-person-popover-simple' ).popover( {
+                        placement: 'right',
+                        trigger: 'manual',
+                        sanitize: false,
                         delay: 500,
                         html: true,
                         content: function () {

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -28,9 +28,32 @@
         text-align: center;
     }
 
-    .popover-content header img {
-        width: 64px;
+    .js-person-popover-stepstocare + .popover {
+        max-width: 100%;
     }
+
+        .js-person-popover-stepstocare + .popover .popover-content .person-image {
+            float: left;
+            width: 70px;
+            height: 70px;
+            margin-right: 8px;
+            background-position: 50%;
+            background-size: cover;
+            border: 1px solid #dfe0e1;
+        }
+
+        .js-person-popover-stepstocare + .popover .popover-content .contents {
+            float: left;
+            width: calc(100% - 78px);
+        }
+
+        .js-person-popover-stepstocare + .popover .popover-content .email {
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+            width: 100%;
+            display: inline-block;
+        }
 
     .hasParentNeed {
         background-color: #ececec !important;
@@ -199,7 +222,7 @@
                     });
 
                     // person-link-popover
-                    $('.js-person-popover').popover({
+                    $('.js-person-popover-stepstocare').popover({
                         placement: 'right',
                         trigger: 'manual',
                         sanitize: false,
@@ -207,19 +230,16 @@
                         html: true,
                         content: function ()
                         {
-                            var dataUrl = Rock.settings.get( 'baseUrl' ) + 'api/People/PopupHtml/' + $( this ).attr( 'personid' ) + '/true';
+                            var dataUrl = Rock.settings.get( 'baseUrl' ) + 'api/People/GetSearchDetails?id=' + $( this ).attr( 'personid' ) + '';
 
                             var result = $.ajax( {
                                 type: 'GET',
                                 url: dataUrl,
-                                dataType: 'json',
-                                contentType: 'application/json; charset=utf-8',
+                                dataType: 'text/html',
                                 async: false
                             } ).responseText;
 
-                            var resultObject = JSON.parse( result );
-
-                            return resultObject.PickerItemDetailsHtml;
+                            return result.replace( /^"/i, '' ).replace( /"$/i, '' ).replace( /\\"/ig, '"' ).replace( /<span class=['"]email['"]>(.*)<\/span>/ig, '<a href="/Communication?person=' + $( this ).attr( 'personid' ) + '" class="email">$1</a>' );
 
                         }
                     }).on('mouseenter', function () {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -362,7 +362,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         /// </summary>
         private bool _canViewCareWorker = false;
 
-        private readonly string _photoFormat = "<div class=\"photo-icon photo-round photo-round-xs pull-left margin-r-sm js-person-popover\" personid=\"{0}\" data-original=\"{1}&w=50\" style=\"background-image: url( '{2}' ); background-size: cover; background-repeat: no-repeat;\"></div>";
+        private readonly string _photoFormat = "<div class=\"photo-icon photo-round photo-round-xs pull-left margin-r-sm js-person-popover-simple\" personid=\"{0}\" data-original=\"{1}&w=50\" style=\"background-image: url( '{2}' ); background-size: cover; background-repeat: no-repeat;\"></div>";
 
         private List<NoteTypeCache> _careNeedNoteTypes = new List<NoteTypeCache>();
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -1087,7 +1087,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         }
                         if ( careNeed.PersonAlias != null )
                         {
-                            lName.Text = string.Format( "{3} {4} <a href=\"{0}\" class=\"js-person-popover\" personid=\"{5}\">{1}</a> {2}", ResolveUrl( string.Format( "~/Person/{0}", careNeed.PersonAlias.PersonId ) ), careNeed.PersonAlias.Person.FullName ?? string.Empty, careNeedFlagStr, childNeedStr, parentNeedStr, careNeed.PersonAlias.PersonId );
+                            lName.Text = string.Format( "{3} {4} <a href=\"{0}\" class=\"js-person-popover-stepstocare\" personid=\"{5}\">{1}</a> {2}", ResolveUrl( string.Format( "~/Person/{0}", careNeed.PersonAlias.PersonId ) ), careNeed.PersonAlias.Person.FullName ?? string.Empty, careNeedFlagStr, childNeedStr, parentNeedStr, careNeed.PersonAlias.PersonId );
                         }
                     }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Steps to care Popover Update, change from just name and photo to pull full contact information into popover instead.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Updated care requester name popover to include contact information instead of just the name and photo.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

Before change:   
<img alt="image" src="https://github.com/KingdomFirst/RockBlocks/assets/2990519/bfd5311e-47a1-44d4-b61c-cceb27682f58">

After Change:   
![image](https://github.com/KingdomFirst/RockBlocks/assets/2990519/8d6ac591-6f57-4e95-b9d2-47d74bb8f892)


---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
