### PR TITLE
Business Edit Update

### DIFF
--- a/Crm/EditBusiness.ascx.cs
+++ b/Crm/EditBusiness.ascx.cs
@@ -578,7 +578,7 @@ namespace RockWeb.Plugins.rocks_kfs.Crm
             hfBusinessId.Value = Person.Id.ToString();
 
             imgPhoto.BinaryFileId = Person.PhotoId;
-            imgPhoto.NoPictureUrl = Person.GetPersonPhotoUrl( this.Person.Id, this.Person.PhotoId, null, Gender.Unknown, Rock.SystemGuid.DefinedValue.PERSON_RECORD_TYPE_BUSINESS.AsGuid(), null, 400, 400 );
+            imgPhoto.NoPictureUrl = Person.GetPersonNoPictureUrl( this.Person, 400, 400 );
 
             lTitle.Text = ActionTitle.Edit( business.FullName ).FormatAsHtmlTitle();
             tbBusinessName.Text = business.LastName;


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Replace deprecated/obsolete method with new GetNoPictureUrl method.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Replace deprecated/obsolete method with new GetNoPictureUrl method.

---------

### Requested By

##### Who reported, requested, or paid for the change?

WCD

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Crm/EditBusiness.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

The core rock change was a breaking change, though it should have just been marked obsolete without exception... The new method we are pointing to should be v14+ at least.
