### PR TITLE
Update Spreadsheet Import person import SQL for newer Rock versions

### DIFF
--- a/Import/sql/_rocks_kfs_spPersonImport_CSV.sql
+++ b/Import/sql/_rocks_kfs_spPersonImport_CSV.sql
@@ -23,6 +23,10 @@ Assumptions:
 Installation:
 - CREATE PROCEDURE [dbo].[_rocks_kfs_spPersonImport_CSV] AS ;
 
+Updates:
+- Added GroupTypeId to the GroupMember insert process to support
+  new Rock model requirement - GM 2/1/2024
+
 **************************************************************/
 
 SET NOCOUNT ON
@@ -200,6 +204,7 @@ SELECT @cmd = '
 ;WITH NewGroupMembers AS (
 SELECT t.GroupId,
     t.PersonId,
+    g.[GroupTypeId],
     gt.[DefaultGroupRoleId]
 FROM _rocks_kfs_peopleCsvTemp t
 LEFT OUTER JOIN [GroupMember] gm ON t.[PersonId] = gm.[PersonId] and gm.[GroupId] = t.GroupId
@@ -207,8 +212,8 @@ JOIN [Group] g ON t.[GroupId] = g.[Id]
 JOIN [GroupType] gt ON g.[GroupTypeId] = gt.[Id]
 WHERE gm.[Id] IS NULL
 )
-INSERT GroupMember( IsSystem, GroupId, PersonId, GroupRoleId, GroupMemberStatus, [Guid], CreatedDateTime, ModifiedDateTime, DateTimeAdded, IsNotified, IsArchived )
-SELECT DISTINCT 0, GroupId, PersonId, DefaultGroupRoleId, 1, NEWID(), GETDATE(), GETDATE(), GETDATE(), 0, 0
+INSERT GroupMember( IsSystem, GroupId, GroupTypeId, PersonId, GroupRoleId, GroupMemberStatus, [Guid], CreatedDateTime, ModifiedDateTime, DateTimeAdded, IsNotified, IsArchived )
+SELECT DISTINCT 0, GroupId, GroupTypeId, PersonId, DefaultGroupRoleId, 1, NEWID(), GETDATE(), GETDATE(), GETDATE(), 0, 0
 FROM NewGroupMembers
 ';
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Rock now requires GroupTypeId while inserting records into the GroupMember table. This change adds the necessary GroupTypeId field to the GroupMember portion of the _rocks_kfs_spPersonImport_CSV stored procedure.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed bug causing error when using _rocks_kfs_spPersonImport_CSV stored procedure with KFS Spreadsheet Import block.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Manna

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Import/sql/_rocks_kfs_spPersonImport_CSV.sql

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
