### PR TITLE
Group Selected Communication - Form Input Name

### DIFF
--- a/Groups/GroupSelectedCommunication.ascx.cs
+++ b/Groups/GroupSelectedCommunication.ascx.cs
@@ -45,6 +45,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
     [CodeEditorField( "Alternate Communication Button Text", "The text to use on the button for Alternate Communication button for Selected Members", CodeEditorMode.Text, CodeEditorTheme.Rock, 20, true, "<i class='fa fa-comment-o'></i> Text Selected Members", "Text", 4 )]
     [TextField( "Communication Button CSS Class", "The css classes used on the 'Email Selected Members' button.", true, "btn btn-default btn-xs", "CSS Classes", 5 )]
     [TextField( "Alternate Communication Button CSS Class", "The css classes used on the 'Text Selected Members' button.", true, "btn btn-default btn-xs", "CSS Classes", 6 )]
+    [TextField( "Form Input Name", "The form input name, so you can use multiple copies of the block on the same page.", true, "selectedmembers", "", 7 )]
 
     #endregion
 
@@ -157,7 +158,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
 
         private Dictionary<string, string> CreateCommunication()
         {
-            var selectedMembers = Request.Form["selectedmembers"];
+            var selectedMembers = Request.Form[GetAttributeValue( "FormInputName" )];
             var selectedIds = new List<string>();
             if ( selectedMembers != null && !string.IsNullOrWhiteSpace( selectedMembers ) )
             {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Gives the capability to specify what form input name to use, so you can use multiple copies of the blocks on the same page or customize the input name.

**New Settings:**

_Form Input Name_, The form input name, so you can use multiple copies of the block on the same page.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added the capability to specify what form input name to use, so you can use multiple copies of the blocks on the same page or customize the input name.

---------

### Requested By

##### Who reported, requested, or paid for the change?

North Coast

---------

### Screenshots

##### Does this update or add options to the block UI?

<img width="598" alt="image" src="https://github.com/KingdomFirst/RockBlocks/assets/2990519/48ef4dd0-7a32-408a-b472-7cac6cb73788">

---------

### Change Log

##### What files does it affect?

Groups/GroupSelectedCommunication.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
