### PR TITLE
Eventbrite Bug Fix

### DIFF
--- a/Eventbrite/EventbriteSettings.ascx.cs
+++ b/Eventbrite/EventbriteSettings.ascx.cs
@@ -298,25 +298,29 @@ namespace RockWeb.Plugins.rocks_kfs.Eventbrite
                 {
                     lblLoginStatus.Text = "Authenticated";
                     lblLoginStatus.CssClass = "pull-right label label-success";
+
+                    pnlGridWrapper.Visible = true;
+                    pnlCreateGroupFromEventbrite.Visible = true;
+                    _groups = new EventbriteEvents().Events( GetAttributeValue( "DisplayEventbriteEventName" ).AsBoolean() );
+                    gEBLinkedGroups.DataSource = _groups;
+                    gEBLinkedGroups.DataBind();
                 }
                 else
                 {
                     lblLoginStatus.Text = "Not authenticated";
                     lblLoginStatus.CssClass = "pull-right label label-danger";
                     tbOAuthToken.Text = "";
+                    pnlGridWrapper.Visible = false;
+                    pnlCreateGroupFromEventbrite.Visible = false;
                 }
                 lView.Text = new DescriptionList()
                     .Add( "Private Token", _accessToken )
                     .Add( "Organization", Settings.GetOrganizationId() )
                     .Html;
-                pnlToken.Visible = false;
-                nbNotification.Visible = showNotificationbox;
-                pnlGridWrapper.Visible = true;
                 lView.Visible = true;
                 btnEdit.Visible = true;
-                _groups = new EventbriteEvents().Events( GetAttributeValue( "DisplayEventbriteEventName" ).AsBoolean() );
-                gEBLinkedGroups.DataSource = _groups;
-                gEBLinkedGroups.DataBind();
+                pnlToken.Visible = false;
+                nbNotification.Visible = showNotificationbox;
             }
         }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

In Eventbrite settings block I went ahead and moved the databind behind isAuthenticated check.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an issue that could sometimes generate an exception on the settings block if the token was entered but invalid.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

Before:   
![image](https://github.com/KingdomFirst/RockBlocks/assets/2990519/e168e1fd-2ca9-4ec4-8909-243e27b35bd2)
(or an exception if "Display Eventbrite Event Name" setting was set to "Yes")

After (no longer displays grid or attempts api calls):   
![image](https://github.com/KingdomFirst/RockBlocks/assets/2990519/c1cdd9dd-070a-4af1-b140-d8f908cebb78)

---------

### Change Log

##### What files does it affect?

Eventbrite/EventbriteSettings.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
