### PR TITLE
Steps to Care - Minor Fix and Editable Follow Up Workers

### DIFF
--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -886,7 +886,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                 {
                                     e.Row.AddCssClass( "assigned" );
                                 }
-                                if ( assignedPerson.WorkerId.HasValue && assignedPerson.FollowUpWorker.HasValue && assignedPerson.FollowUpWorker.Value )
+                                if ( assignedPerson.WorkerId.HasValue && assignedPerson.FollowUpWorker )
                                 {
                                     assignedFollowUpWorker = assignedPerson;
                                 }

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -870,7 +870,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         }
                     }
 
-                    AssignedPerson assignedFollowUpWorker = null;
+                    List<int> assignedFollowUpWorkers = new List<int>();
                     var assignedFollowUpWorkerCareTouch = false;
                     Literal lAssigned = e.Row.FindControl( "lAssigned" ) as Literal;
                     if ( lAssigned != null )
@@ -886,9 +886,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                 {
                                     e.Row.AddCssClass( "assigned" );
                                 }
-                                if ( assignedPerson.WorkerId.HasValue && assignedPerson.FollowUpWorker )
+                                if ( assignedPerson.FollowUpWorker && assignedPerson.PersonAliasId.HasValue )
                                 {
-                                    assignedFollowUpWorker = assignedPerson;
+                                    assignedFollowUpWorkers.Add( assignedPerson.PersonAliasId.Value );
                                 }
                             }
                             lAssigned.Text = sbPersonHtml.ToString();
@@ -962,9 +962,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                 lCareTouches.Text = careNeedNotes.Count().ToString();
                                 careTouchCount = careNeedNotes.Count();
 
-                                if ( assignedFollowUpWorker != null )
+                                if ( assignedFollowUpWorkers.Any() )
                                 {
-                                    assignedFollowUpWorkerCareTouch = careNeedNotes.Any( n => n.CreatedByPersonAliasId == assignedFollowUpWorker.PersonAliasId );
+                                    assignedFollowUpWorkerCareTouch = careNeedNotes.Any( n => assignedFollowUpWorkers.Contains( n.CreatedByPersonAliasId.Value ) );
                                 }
                             }
                             else

--- a/StepsToCare/CareEntry.ascx
+++ b/StepsToCare/CareEntry.ascx
@@ -124,7 +124,8 @@
                         <Columns>
                             <Rock:SelectField></Rock:SelectField>
                             <asp:BoundField DataField="PersonAlias.Person.FullName" HeaderText="Name" SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName" />
-                            <Rock:CheckBoxEditableField HeaderText="Follow Up Worker" DataField="FollowUpWorker"></Rock:CheckBoxEditableField>
+                            <Rock:BoolField HeaderText="Follow Up Worker" DataField="FollowUpWorker"></Rock:BoolField>
+                            <Rock:CheckBoxEditableField HeaderText="Follow Up Worker" DataField="FollowUpWorker" HeaderStyle-CssClass="text-center" ItemStyle-CssClass="w-auto"></Rock:CheckBoxEditableField>
                             <Rock:RockTemplateField HeaderText="Type (Need Count)">
                                 <ItemTemplate>
                                     <asp:PlaceHolder runat="server" ID="phCountOrRole"></asp:PlaceHolder>

--- a/StepsToCare/CareEntry.ascx
+++ b/StepsToCare/CareEntry.ascx
@@ -124,7 +124,7 @@
                         <Columns>
                             <Rock:SelectField></Rock:SelectField>
                             <asp:BoundField DataField="PersonAlias.Person.FullName" HeaderText="Name" SortExpression="PersonAlias.Person.LastName, PersonAlias.Person.NickName" />
-                            <Rock:BoolField HeaderText="Follow Up Worker" DataField="FollowUpWorker"></Rock:BoolField>
+                            <Rock:CheckBoxEditableField HeaderText="Follow Up Worker" DataField="FollowUpWorker"></Rock:CheckBoxEditableField>
                             <Rock:RockTemplateField HeaderText="Type (Need Count)">
                                 <ItemTemplate>
                                     <asp:PlaceHolder runat="server" ID="phCountOrRole"></asp:PlaceHolder>

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -131,7 +131,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.EnableCustomFollowUp )]
 
     [CustomDropdownListField( "Follow Up Worker Assignment",
-        Description = "Enable the follow up worker to be assigned instead of just auto assigning the first worker added to need. Hide, existing behavior first worker gets assignment. Show, show a checkbox to assign follow up worker with first worker checked by default. Show and Assign All, show the checkbox and select all as default.",
+        Description = "Enable the follow up worker to be assigned instead of just auto assigning the first worker added to need. Hide: First worker gets assignment (existing behavior). Show: Show a checkbox to assign follow up worker with first worker checked by default. Show and Assign All: Show the checkbox and select all as default.",
         IsRequired = true,
         ListSource = "Hide,Show,Show and Assign All",
         DefaultValue = "Hide",
@@ -517,8 +517,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                                     if ( checkBoxTemplateField != null && checkBoxTemplateField.Visible )
                                     {
                                         CheckBox checkBox = fieldCell.Controls[0] as CheckBox;
-                                        string dataField = ( fieldCell.ContainingField as CheckBoxEditableField ).DataField;
-
                                         assignedPerson.FollowUpWorker = checkBox.Checked;
                                     }
                                 }

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -131,7 +131,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Key = AttributeKey.EnableCustomFollowUp )]
 
     [CustomDropdownListField( "Follow Up Worker Assignment",
-        Description = "Enable the follow up worker to be assigned instead of just auto assigning the first worker added to need. Hide: First worker gets assignment (existing behavior). Show: Show a checkbox to assign follow up worker with first worker checked by default. Show and Assign All: Show the checkbox and select all as default.",
+        Description = "Enable the follow up worker to be assigned instead of auto assigning the first worker added to need. <br><b>Hide:</b> First worker gets assignment (existing behavior). <br><b>Show:</b> Show a checkbox to assign follow up worker with first worker checked by default. <br><b>Show and Assign All:</b> Show the checkbox and select all as default.",
         IsRequired = true,
         ListSource = "Hide,Show,Show and Assign All",
         DefaultValue = "Hide",

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -1279,12 +1279,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 pwAssigned.Visible = UserCanAdministrate;
                 BindAssignedPersonsGrid();
             }
-            else
+            else if ( needId == 0 )
             {
                 GenerateTempNeed( null, categoryId );
 
                 pwAssigned.Visible = false;
                 AssignedPersons = null;
+            }
+            else
+            {
+                GenerateTempNeed( null, categoryId );
             }
         }
 

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -495,6 +495,28 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                         assignedPersonService.DeleteRange( removePersons );
                         careNeed.AssignedPersons.RemoveAll( removePersons );
 
+                        // Go through each assigned person on the grid and mark whether they are follow up worker or not based on checkbox.
+                        var gridViewRows = gAssignedPersons.Rows;
+                        foreach ( GridViewRow row in gridViewRows.OfType<GridViewRow>() )
+                        {
+                            int assignedPersonAliasId = gAssignedPersons.DataKeys[row.RowIndex].Value.ToIntSafe( -1 );
+                            var assignedPerson = careNeed.AssignedPersons.FirstOrDefault( ap => ap.PersonAliasId == assignedPersonAliasId );
+                            if ( assignedPerson != null )
+                            {
+                                foreach ( var fieldCell in row.Cells.OfType<DataControlFieldCell>() )
+                                {
+                                    CheckBoxEditableField checkBoxTemplateField = fieldCell.ContainingField as CheckBoxEditableField;
+                                    if ( checkBoxTemplateField != null )
+                                    {
+                                        CheckBox checkBox = fieldCell.Controls[0] as CheckBox;
+                                        string dataField = ( fieldCell.ContainingField as CheckBoxEditableField ).DataField;
+
+                                        assignedPerson.FollowUpWorker = checkBox.Checked;
+                                    }
+                                }
+                            }
+                        }
+
                         if ( enableLogging )
                         {
                             CareUtilities.LogEvent( null, "UpdateAssignedPersons", string.Format( "Care Need Guid: {0}, AssignedPersons Count: {1} careNeed.AssignedPersons Count: {2} removePersons Count {3} Edited By AliasId: {4}", careNeed.Guid, AssignedPersons.Count(), careNeed.AssignedPersons.Count(), removePersons.Count(), CurrentPersonAlias.Id ), "Assigned Persons Edit End" );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Minor fix for Assigned Person grid not showing on edit.
- Added ability to be able to set who are the follow up workers on needs.

**New Settings:**

- _Follow Up Worker Assignment_, Enable the follow up worker to be assigned instead of just auto assigning the first worker added to need. Hide, existing behavior first worker gets assignment. Show, show a checkbox to assign follow up worker with first worker checked by default. Show and Assign All, show the checkbox and select all as default.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Minor fix for Assigned Person grid not showing on edit.
- Added ability to be able to set who are the follow up workers on needs.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/KingdomFirst/RockBlocks/assets/2990519/2f6724cd-a1f6-419d-a4ca-69db1f27518d)

![image](https://github.com/KingdomFirst/RockBlocks/assets/2990519/24db2762-9598-4125-8762-c7cfaba0f03d)

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareEntry.ascx
- StepsToCare/CareEntry.ascx.cs
- StepsToCare/CareDashboard.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, though it does require migration/new dll from [RockAssemblies#147](https://github.com/KingdomFirst/RockAssemblies/pull/147) to work properly.
