### PR TITLE
RSVP Group Reg Fix

### DIFF
--- a/RsvpGroups/Lava/RsvpGroupListSidebar.lava
+++ b/RsvpGroups/Lava/RsvpGroupListSidebar.lava
@@ -2,8 +2,8 @@
   <div class="panel-heading">
     {% if ShowInactive -%}{% assign inactiveParamVal = 'Global' | PageParameter:InactiveParameter -%}
     <div class="pull-right btn-group btn-toggle">
-      <a class="btn btn-default btn-xs {% if inactiveParamVal == '0' or InitialActive == 1 and inactiveParamVal == null %}active{% endif %}" href='{{ 'Global=''' | Page:'Path=''' }}?{{ InactiveParameter }}=0'>Active</a>
-      <a class="btn btn-default btn-xs {% if inactiveParamVal == '1' or InitialActive == 0 and PainactiveParamVal == null %}active{% endif %}" href='{{ 'Global=''' | Page:'Path=''' }}?{{ InactiveParameter }}=1'>All</a>
+      <a class="btn btn-default btn-xs {% if inactiveParamVal == '0' or InitialActive == 1 and inactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=0'>Active</a>
+      <a class="btn btn-default btn-xs {% if inactiveParamVal == '1' or InitialActive == 0 and PainactiveParamVal == null %}active{% endif %}" href='{{ 'Global' | Page:'Path' }}?{{ InactiveParameter }}=1'>All</a>
     </div>
     {% endif -%}
     RSVP Groups

--- a/RsvpGroups/RsvpGroupRegistration.ascx.cs
+++ b/RsvpGroups/RsvpGroupRegistration.ascx.cs
@@ -1,4 +1,4 @@
-// <copyright>
+﻿// <copyright>
 // Copyright by the Spark Development Network
 //
 // Licensed under the Rock Community License (the "License");
@@ -626,7 +626,8 @@ namespace RockWeb.Plugins.rocks_kfs.RsvpGroups
                     var subject = group.GetAttributeValue( "Subject" );
 
                     var emailMessage = new RockEmailMessage();
-                    emailMessage.AddRecipient( new RecipientData( groupMember.Person.Email, mergeFields ) );
+                    var emailMessageRecipient = new RockEmailMessageRecipient( groupMember.Person, mergeFields );
+                    emailMessage.AddRecipient( emailMessageRecipient );
 
                     emailMessage.FromEmail = fromEmail;
                     emailMessage.FromName = fromName;


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed old block to use newer v11+ methods.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Updated RSVP Group Registration to work on v11+

---------

### Requested By

##### Who reported, requested, or paid for the change?

KCC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- RsvpGroups/Lava/RsvpGroupListSidebar.lava
- RsvpGroups/RsvpGroupRegistration.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
