### PR TITLE
Advanced Checkin Monitor - Fixed ambiguous reference bug in Locations block caused by Rock v16.6 changes

### DIFF
--- a/CheckIn/Manager/Locations.ascx.cs
+++ b/CheckIn/Manager/Locations.ascx.cs
@@ -48,6 +48,7 @@ using Rock.Security;
 using Rock.Web.Cache;
 using Rock.Web.UI.Controls;
 using Group = Rock.Model.Group;
+using CheckInLabel = Rock.CheckIn.CheckInLabel;
 
 namespace RockWeb.Plugins.rocks_kfs.CheckIn.Manager
 {

--- a/CheckIn/Manager/ReadMe.md
+++ b/CheckIn/Manager/ReadMe.md
@@ -2,9 +2,9 @@
 
 
 # Advanced Check-In Monitor
-_Tested/Supported in Rock Version:  8.0-12.0_    
+_Tested/Supported in Rock Version:  8.0-16.6_    
 _Released:  12/31/2018_   
-_Updated:  4/26/2021_   
+_Updated:  8/6/2024_   
 
 ## Summary
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Rock added a new CheckInLabel class to Rock.Model in v [16.6](https://github.com/SparkDevNetwork/Rock/commit/f36a49f54ac9c73e063927b717634e1ce3d6099d#diff-ada733893782d8d503f6997750703c30c2c147d479025f288f011eb92c7d5cdc), causing an ambiguous reference with Rock.Checkin.CheckInLabel class when both namespaces are referenced. This change resolves the ambiguous reference.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed CheckInLabel ambiguous reference error introduced with version 16.6 of Rock.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

* CheckIn/Manager/Locations.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
