### PR TITLE
Steps to Care Assign to Group(s) changes and minor bug fix

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -163,7 +163,7 @@
                                     Total Care Needs
                                 </a>
                             </li>
-                            <li class="block-status care-enter-need">
+                            <li class="block-status care-enter-need" id="liEnterNeed" runat="server">
                                 <asp:LinkButton ID="btnAdd" runat="server" CssClass="btn btn-default" OnClick="gList_AddClick"><i class='fas fa-plus'></i><strong class="text-uppercase">Enter Care Need</strong></asp:LinkButton>
                             </li>
                             <li class="block-status care-categories">

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -358,6 +358,8 @@
                     <asp:Panel ID="pnlQuickNoteText" runat="server" CssClass="noteentry-control meta-body" Visible="false">
                         <Rock:RockTextBox ID="rtbNote" runat="server" Placeholder="Write an additional note..." Rows="3" TextMode="MultiLine" ValidationGroup="QuickNoteMakeNote"></Rock:RockTextBox>
                         <div class="settings clearfix">
+                            <asp:Checkbox ID="cbAlert" runat="server" Text="Alert" CssClass="js-notealert" />
+                            <asp:Checkbox ID="cbPrivate" runat="server" Text="Private" CssClass="js-noteprivate" />
                             <Rock:BootstrapButton ID="rbBtnQuickNoteSave" runat="server" DataLoadingText="Saving..." Text="Save Note" CssClass="commands btn btn-primary btn-xs" OnClick="rbBtnQuickNoteSave_Click" ValidationGroup="QuickNoteMakeNote"></Rock:BootstrapButton>
                         </div>
                     </asp:Panel>

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -916,7 +916,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         {
             if ( AvailableAttributes != null )
             {
-                var attribute = AvailableAttributes.FirstOrDefault( a => a.Key == e.Key );
+                var attribute = AvailableAttributes.FirstOrDefault( a => "filter_followup_" + a.Key == e.Key );
                 if ( attribute != null )
                 {
                     try

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -90,8 +90,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Order = 4,
         Key = AttributeKey.MinimumFollowUpTouchHours )]
 
-    [BooleanField( "Enter Care Need Edit Permission",
-        Description = "Should the \"Enter Care Need\" large button be protected by the edit permission?",
+    [BooleanField( "Override New Care Need Edit Permission",
+        Description = "Should the Add Care Need buttons be protected by the edit permission?",
         DefaultBooleanValue = false,
         Order = 5,
         Key = AttributeKey.EnterCareNeed )]
@@ -2199,7 +2199,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             var rockControl = ( IRockControl ) controlFollowUp;
                             rockControl.Label = attribute.Name;
                             rockControl.Help = attribute.Description;
-                            phAttributeFilters.Controls.Add( controlFollowUp );
                             phFollowUpAttributeFilters.Controls.Add( controlFollowUp );
                         }
                         else
@@ -2208,7 +2207,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             wrapper.ID = controlFollowUp.ID + "_wrapper";
                             wrapper.Label = attribute.Name;
                             wrapper.Controls.Add( controlFollowUp );
-                            phAttributeFilters.Controls.Add( wrapper );
                             phFollowUpAttributeFilters.Controls.Add( wrapper );
                         }
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2159,6 +2159,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 foreach ( var attribute in AvailableAttributes )
                 {
                     var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
+                    var controlFollowUp = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_followup_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
                     if ( control != null )
                     {
                         if ( control is IRockControl )
@@ -2167,7 +2168,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             rockControl.Label = attribute.Name;
                             rockControl.Help = attribute.Description;
                             phAttributeFilters.Controls.Add( control );
-                            phFollowUpAttributeFilters.Controls.Add( control );
                         }
                         else
                         {
@@ -2175,6 +2175,39 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             wrapper.ID = control.ID + "_wrapper";
                             wrapper.Label = attribute.Name;
                             wrapper.Controls.Add( control );
+                            phAttributeFilters.Controls.Add( wrapper );
+                        }
+
+                        string savedValue = rFilter.GetUserPreference( attribute.Key );
+                        if ( !string.IsNullOrWhiteSpace( savedValue ) )
+                        {
+                            try
+                            {
+                                var values = JsonConvert.DeserializeObject<List<string>>( savedValue );
+                                attribute.FieldType.Field.SetFilterValues( control, attribute.QualifierValues, values );
+                            }
+                            catch
+                            {
+                                // intentionally ignore
+                            }
+                        }
+                    }
+                    if ( controlFollowUp != null )
+                    {
+                        if ( controlFollowUp is IRockControl )
+                        {
+                            var rockControl = ( IRockControl ) controlFollowUp;
+                            rockControl.Label = attribute.Name;
+                            rockControl.Help = attribute.Description;
+                            phAttributeFilters.Controls.Add( controlFollowUp );
+                            phFollowUpAttributeFilters.Controls.Add( controlFollowUp );
+                        }
+                        else
+                        {
+                            var wrapper = new RockControlWrapper();
+                            wrapper.ID = controlFollowUp.ID + "_wrapper";
+                            wrapper.Label = attribute.Name;
+                            wrapper.Controls.Add( controlFollowUp );
                             phAttributeFilters.Controls.Add( wrapper );
                             phFollowUpAttributeFilters.Controls.Add( wrapper );
                         }
@@ -2185,7 +2218,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             try
                             {
                                 var values = JsonConvert.DeserializeObject<List<string>>( savedValue );
-                                attribute.FieldType.Field.SetFilterValues( control, attribute.QualifierValues, values );
+                                attribute.FieldType.Field.SetFilterValues( controlFollowUp, attribute.QualifierValues, values );
                             }
                             catch
                             {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2534,6 +2534,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( cn => cn.AssignedPersons.Count( ap => ap.PersonAliasId == CurrentPersonAliasId ) > 0 );
             }
 
+            // Filter query by any configured attribute filters
+            if ( AvailableAttributes != null && AvailableAttributes.Any() )
+            {
+                foreach ( var attribute in AvailableAttributes )
+                {
+                    var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
+                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
+                }
+            }
+
             SortProperty sortProperty = gList.SortProperty;
             if ( sortProperty != null )
             {
@@ -2565,16 +2575,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     .ThenByDescending( a => a.DateEntered )
                     .ThenBy( a => a.ParentNeedId )
                     .ThenByDescending( a => a.Id );
-            }
-
-            // Filter query by any configured attribute filters
-            if ( AvailableAttributes != null && AvailableAttributes.Any() )
-            {
-                foreach ( var attribute in AvailableAttributes )
-                {
-                    var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
-                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
-                }
             }
 
             var list = qry.ToList();
@@ -2691,6 +2691,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( cn => cn.AssignedPersons.Count( ap => ap.PersonAliasId == CurrentPersonAliasId ) > 0 );
             }
 
+            // Filter query by any configured attribute filters
+            if ( AvailableAttributes != null && AvailableAttributes.Any() )
+            {
+                foreach ( var attribute in AvailableAttributes )
+                {
+                    var filterControl = phFollowUpAttributeFilters.FindControl( "filter_followup_" + attribute.Id.ToString() );
+                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
+                }
+            }
+
             SortProperty sortProperty = gFollowUp.SortProperty;
             if ( sortProperty != null )
             {
@@ -2717,16 +2727,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             else
             {
                 qry = qry.OrderByDescending( a => a.DateEntered ).ThenByDescending( a => a.Id );
-            }
-
-            // Filter query by any configured attribute filters
-            if ( AvailableAttributes != null && AvailableAttributes.Any() )
-            {
-                foreach ( var attribute in AvailableAttributes )
-                {
-                    var filterControl = phFollowUpAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
-                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
-                }
             }
 
             var list = qry.ToList();

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -82,6 +82,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Order = 4,
         Key = AttributeKey.MinimumCareTouchHours )]
 
+    [BooleanField( "Enter Care Need Edit Permission",
+        Description = "Should the \"Enter Care Need\" large button be protected by the edit permission?",
+        DefaultBooleanValue = false,
+        Order = 5,
+        Key = AttributeKey.EnterCareNeed )]
+
     [DefinedValueField(
         "Outstanding Care Needs Statuses",
         Description = "Select the status values that count towards the 'Outstanding Care Needs' total.",
@@ -331,6 +337,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string TouchNeededTooltipTemplate = "TouchNeededTooltipTemplate";
             public const string QuickNoteStatusTemplate = "QuickNoteStatusTemplate";
             public const string QuickNoteAutoSave = "QuickNoteAutoSave";
+            public const string EnterCareNeed = "EnterCareNeed";
         }
 
         /// <summary>
@@ -600,6 +607,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             gFollowUp.Actions.ShowAdd = false;
             gFollowUp.Actions.ShowMergeTemplate = false;
             gFollowUp.IsDeleteEnabled = _canAdministrate;
+
+            var enterCareNeedEditPermission = GetAttributeValue( AttributeKey.EnterCareNeed ).AsBoolean();
+            liEnterNeed.Visible = _canEdit || !enterCareNeedEditPermission;
 
             mdMakeNote.Footer.Visible = false;
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -825,6 +825,24 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         /// <param name="e">The e.</param>
         protected void rFilter_DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
         {
+            if ( AvailableAttributes != null )
+            {
+                var attribute = AvailableAttributes.FirstOrDefault( a => a.Key == e.Key );
+                if ( attribute != null )
+                {
+                    try
+                    {
+                        var values = JsonConvert.DeserializeObject<List<string>>( e.Value );
+                        e.Value = attribute.FieldType.Field.FormatFilterValues( attribute.QualifierValues, values );
+                        return;
+                    }
+                    catch
+                    {
+                        // intentionally ignore
+                    }
+                }
+            }
+
             switch ( e.Key )
             {
                 case UserPreferenceKey.StartDate:
@@ -896,6 +914,24 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         /// <param name="e">The e.</param>
         protected void rFollowUpFilter_DisplayFilterValue( object sender, GridFilter.DisplayFilterValueArgs e )
         {
+            if ( AvailableAttributes != null )
+            {
+                var attribute = AvailableAttributes.FirstOrDefault( a => a.Key == e.Key );
+                if ( attribute != null )
+                {
+                    try
+                    {
+                        var values = JsonConvert.DeserializeObject<List<string>>( e.Value );
+                        e.Value = attribute.FieldType.Field.FormatFilterValues( attribute.QualifierValues, values );
+                        return;
+                    }
+                    catch
+                    {
+                        // intentionally ignore
+                    }
+                }
+            }
+
             switch ( e.Key )
             {
                 case UserPreferenceKey.StartDateFollowUp:

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2008,7 +2008,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 var closeDialogOnSave = GetAttributeValue( AttributeKey.CloseDialogOnSave ).AsBoolean();
                 var careNeedId = hfCareNeedId.ValueAsInt();
 
-                var noteCreated = createNote( rockContext, careNeedId, $"{noteTemplate.Note}{( rtbNote.Text.IsNotNullOrWhiteSpace() ? ":" : "" )} {rtbNote.Text}", closeDialogOnSave, noteTemplate, true );
+                var noteCreated = createNote( rockContext, careNeedId, $"{noteTemplate.Note}{( rtbNote.Text.IsNotNullOrWhiteSpace() ? ":" : "" )} {rtbNote.Text}", closeDialogOnSave, noteTemplate, true, cbAlert.Checked, cbPrivate.Checked );
                 if ( noteCreated )
                 {
                     if ( GetAttributeValue( AttributeKey.MoveNeedToSnoozed ).AsBoolean() )
@@ -2776,13 +2776,18 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             notesTimeline.AllowAnonymousEntry = false;
             notesTimeline.SortDirection = ListSortDirection.Descending;
 
+            cbAlert.Visible = noteOptions.ShowAlertCheckBox;
+            cbAlert.Checked = false;
+            cbPrivate.Visible = noteOptions.ShowPrivateCheckBox;
+            cbPrivate.Checked = false;
+
             var noteEditor = ( NoteEditor ) notesTimeline.Controls[0];
             noteEditor.CssClass = "note-new-kfs";
             noteEditor.SaveButtonClick += mdMakeNote_SaveClick;
             noteEditor.Focus();
         }
 
-        private bool createNote( RockContext rockContext, int entityId, string noteText, bool displayDialog = false, NoteTemplate noteTemplate = null, bool countsForTouch = false )
+        private bool createNote( RockContext rockContext, int entityId, string noteText, bool displayDialog = false, NoteTemplate noteTemplate = null, bool countsForTouch = false, bool isAlert = false, bool isPrivate = false )
         {
             var noteService = new NoteService( rockContext );
             var noteType = _careNeedNoteTypes.FirstOrDefault();
@@ -2794,7 +2799,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 {
                     Id = 0,
                     IsSystem = false,
-                    IsAlert = false,
+                    IsAlert = isAlert,
+                    IsPrivateNote = isPrivate,
                     NoteTypeId = noteType.Id,
                     EntityId = entityId,
                     Text = noteText,

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -1044,7 +1044,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             {
                                 var careNeedNotes = new NoteService( rockContext )
                                     .GetByNoteTypeId( noteType.Id ).AsNoTracking()
-                                    .Where( n => n.EntityId == careNeed.Id && !n.Caption.StartsWith( "Action" ) );
+                                    .Where( n => n.EntityId == careNeed.Id && ( n.Caption == null || !n.Caption.StartsWith( "Action" ) ) );
                                 careNeedNotesList = careNeedNotes.ToList();
 
                                 lCareTouches.Text = careNeedNotes.Count().ToString();
@@ -2316,7 +2316,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var currentDateTime = RockDateTime.Now;
                 var last7Days = currentDateTime.AddDays( -7 );
-                var careTouches = noteQry.Count( n => n.CreatedDateTime >= last7Days && n.CreatedDateTime <= currentDateTime && !n.Caption.StartsWith( "Action" ) );
+                var careTouches = noteQry.Count( n => n.CreatedDateTime >= last7Days && n.CreatedDateTime <= currentDateTime && ( n.Caption == null || !n.Caption.StartsWith( "Action" ) ) );
 
                 lTouchesCount.Text = careTouches.ToString();
                 lCareNeedsCount.Text = outstandingCareNeeds.ToString();
@@ -3021,7 +3021,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var lavaTemplate = GetAttributeValue( AttributeKey.QuickNoteStatusTemplate );
 
-                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson, new Rock.Lava.CommonMergeFieldsOptions { GetLegacyGlobalMergeFields = false } );
+                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
                 mergeFields.Add( "CareNeed", careNeed );
                 mergeFields.Add( "TouchTemplates", catTouchTemplates );
                 mergeFields.Add( "CareNeedNotes", careNeedNotesList.Where( n => n.Caption == null || ( n.Caption != null && !n.Caption.StartsWith( "Action" ) ) ) );

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -586,6 +586,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             this.AddConfigurationUpdateTrigger( upnlCareDashboard );
             rFilter.ApplyFilterClick += rFilter_ApplyFilterClick;
             rFollowUpFilter.ApplyFilterClick += rFollowUpFilter_ApplyFilterClick;
+            rFollowUpFilter.PreferenceKeyPrefix = "FollowUp";
 
             _canEdit = IsUserAuthorized( Authorization.EDIT );
             _canAdministrate = IsUserAuthorized( Authorization.ADMINISTRATE );
@@ -2193,6 +2194,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         {
             if ( AvailableAttributes != null )
             {
+                phAttributeFilters.Controls.Clear();
+                phFollowUpAttributeFilters.Controls.Clear();
                 foreach ( var attribute in AvailableAttributes )
                 {
                     var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -895,6 +895,25 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             returnStr = typeQualifierArray[2];
                         }
                     }
+                    else if ( assignedPerson.Type == AssignedType.TouchTemplateGroup && typeQualifierArray.Length > 1 )
+                    {
+                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+
+                        if ( typeQualifierArray.Length > 4 )
+                        {
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]}";
+                        }
+                        else
+                        {
+                            returnStr = $"Touch Template Group: {typeQualifierArray[1]}";
+                        }
+                    }
+                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 4 )
+                    {
+                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+
+                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]}";
+                    }
                 }
                 phCountOrRole.Controls.Add( new LiteralControl( returnStr ) );
             }

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -897,22 +897,26 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     }
                     else if ( assignedPerson.Type == AssignedType.TouchTemplateGroup && typeQualifierArray.Length > 1 )
                     {
-                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id^[5]Assigned Count
 
-                        if ( typeQualifierArray.Length > 4 )
+                        if ( typeQualifierArray.Length > 5 )
                         {
-                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]}";
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
+                        }
+                        else if ( typeQualifierArray.Length > 4 )
+                        {
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
                         }
                         else
                         {
                             returnStr = $"Touch Template Group: {typeQualifierArray[1]}";
                         }
                     }
-                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 4 )
+                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 5 )
                     {
-                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id^[5]Assigned Count
 
-                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]}";
+                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
                     }
                 }
                 phCountOrRole.Controls.Add( new LiteralControl( returnStr ) );

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -247,15 +247,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             btnComplete.Text = btnCompleteFtr.Text = GetAttributeValue( AttributeKey.CompleteButtonText );
             btnSnooze.Text = btnSnoozeFtr.Text = GetAttributeValue( AttributeKey.SnoozedButtonText );
             cbCustomFollowUp.Visible = GetAttributeValue( AttributeKey.EnableCustomFollowUp ).AsBoolean();
-        }
-
-        /// <summary>
-        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
-        /// </summary>
-        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
-        protected override void OnLoad( EventArgs e )
-        {
-            base.OnLoad( e );
 
             if ( !Page.IsPostBack )
             {
@@ -268,13 +259,22 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 CareNeed item = new CareNeedService( rockContext ).Get( hfCareNeedId.ValueAsInt() );
                 if ( item == null )
                 {
-                    item = new CareNeed();
+                    item = GenerateTempNeed( null );
                 }
                 item.LoadAttributes();
 
                 phAttributes.Controls.Clear();
                 Helper.AddEditControls( item, phAttributes, false, BlockValidationGroup, 2 );
             }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
 
             confirmExit.Enabled = true;
         }
@@ -1327,7 +1327,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 AssignedPersons = CareUtilities.AutoAssignWorkers( careNeed, cbWorkersOnly.Checked, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuids: leaderRoleGuids, previewAssigned: previewAssignedPeople );
                 pwAssigned.Visible = UserCanAdministrate;
-                BindAssignedPersonsGrid();
+                BindAssignedPersonsGrid( true );
             }
             else if ( needId == 0 )
             {
@@ -1335,10 +1335,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 pwAssigned.Visible = false;
                 AssignedPersons = null;
-            }
-            else
-            {
-                GenerateTempNeed( null, categoryId );
             }
         }
 
@@ -1348,17 +1344,27 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             {
                 categoryId = dvpCategory.SelectedValue.AsIntegerOrNull();
             }
+            if ( categoryId == null )
+            {
+                categoryId = Request.Form[dvpCategory.UniqueID].AsIntegerOrNull();
+            }
+            var campusId = cpCampus.SelectedCampusId;
+            if ( campusId == null )
+            {
+                campusId = Request.Form[cpCampus.UniqueID].AsIntegerOrNull();
+            }
+            int? statusId = dvpStatus.SelectedValue.AsIntegerOrNull();
+            if ( statusId == null )
+            {
+                statusId = Request.Form[dvpStatus.UniqueID].AsIntegerOrNull();
+            }
+
             var careNeed = new CareNeed { Id = 0 };
             careNeed.CampusId = cpCampus.SelectedCampusId;
             careNeed.PersonAlias = person?.PrimaryAlias;
             careNeed.PersonAliasId = person?.PrimaryAliasId;
-            careNeed.StatusValueId = dvpStatus.SelectedValue.AsIntegerOrNull();
+            careNeed.StatusValueId = statusId;
             careNeed.CategoryValueId = categoryId;
-
-            careNeed.LoadAttributes();
-
-            phAttributes.Controls.Clear();
-            Helper.AddEditControls( careNeed, phAttributes, false, BlockValidationGroup, 2 );
 
             return careNeed;
         }

--- a/StepsToCare/CareNoteTemplates.ascx.cs
+++ b/StepsToCare/CareNoteTemplates.ascx.cs
@@ -153,7 +153,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             // Parse the attribute filters
             AvailableAttributes = new List<AttributeCache>();
 
-            int entityTypeId = new CareNeed().TypeId;
+            int entityTypeId = new NoteTemplate().TypeId;
             foreach ( var attributeModel in new AttributeService( new RockContext() ).Queryable()
                 .Where( a =>
                     a.EntityTypeId == entityTypeId &&
@@ -350,6 +350,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             tbNote.Text = noteTemplate.Note;
 
             noteTemplate.LoadAttributes();
+            phAttributes.Controls.Clear();
             Helper.AddEditControls( noteTemplate, phAttributes, true, BlockValidationGroup, 2 );
 
             hfNoteTemplateId.Value = noteTemplate.Id.ToString();
@@ -372,9 +373,11 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     noteTemplate = noteTemplateService.Get( noteTemplateId );
                 }
 
+                NoteTemplate lastNoteTemplate = null;
                 if ( noteTemplate == null )
                 {
                     noteTemplate = new NoteTemplate { Id = 0 };
+                    lastNoteTemplate = noteTemplateService.Queryable().OrderByDescending( b => b.Order ).FirstOrDefault();
                 }
 
                 noteTemplate.Icon = tbIcon.Text;
@@ -383,13 +386,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 noteTemplate.IsActive = cbActive.Checked;
 
-                NoteTemplate lastNoteTemplate = noteTemplateService.Queryable().OrderByDescending( b => b.Order ).FirstOrDefault();
 
                 if ( lastNoteTemplate != null )
                 {
                     noteTemplate.Order = lastNoteTemplate.Order + 1;
                 }
-                else
+                else if ( noteTemplate.Id == 0 )
                 {
                     noteTemplate.Order = 0;
                 }

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -440,16 +440,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( b => b.CategoryValues.Contains( categoryValueId.ToString() ) );
             }
 
-            SortProperty sortProperty = gList.SortProperty;
-            if ( sortProperty != null )
-            {
-                qry = qry.Sort( sortProperty );
-            }
-            else
-            {
-                qry = qry.OrderBy( cw => cw.PersonAlias.Person.LastName ).ThenBy( cw => cw.PersonAlias.Person.FirstName ).ThenByDescending( cw => cw.Id );
-            }
-
             // Filter query by any configured attribute filters
             if ( AvailableAttributes != null && AvailableAttributes.Any() )
             {
@@ -458,6 +448,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
                     qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careWorkerService, Rock.Reporting.FilterMode.SimpleFilter );
                 }
+            }
+
+            SortProperty sortProperty = gList.SortProperty;
+            if ( sortProperty != null )
+            {
+                qry = qry.Sort( sortProperty );
+            }
+            else
+            {
+                qry = qry.OrderBy( cw => cw.PersonAlias.Person.LastName ).ThenBy( cw => cw.PersonAlias.Person.FirstName ).ThenByDescending( cw => cw.Id );
             }
 
             var list = qry.ToList();

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2024 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             // Parse the attribute filters
             AvailableAttributes = new List<AttributeCache>();
 
-            int entityTypeId = new CareNeed().TypeId;
+            int entityTypeId = new CareWorker().TypeId;
             foreach ( var attributeModel in new AttributeService( new RockContext() ).Queryable()
                 .Where( a =>
                     a.EntityTypeId == entityTypeId &&
@@ -559,6 +559,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             }
 
             careWorker.LoadAttributes();
+            phAttributes.Controls.Clear();
             Helper.AddEditControls( careWorker, phAttributes, true, BlockValidationGroup, 2 );
 
             ppPerson_SelectPerson( null, null );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Steps to Care Assign to Group(s) changes in Care Entry and minor bug fix. Goes along with https://github.com/KingdomFirst/RockAssemblies/pull/160

**Additional changes:**    
- Fixed Care touches not always counting appropriately.
- Added new setting to hide add button based on edit permission
- Added follow up touch hours setting to dashboard
- Added support for Alert and Private settings with "quick notes" to match note timeline input.
- Fixed attribute support for Care Entry, Care Dashboard, Care Workers and Note Templates (this includes loading attribute values, attribute filters, grid columns and overall lots of bugs with them).

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- New Qualifiers added for Assigned Person grid.
- Fixed Care touches not always counting appropriately.
- Added new setting to hide add button based on edit permission
- Added follow up touch hours setting to dashboard
- Added support for Alert and Private settings with "quick notes" to match note timeline input.
- Fixed attribute support for Care Entry, Care Dashboard, Care Workers and Note Templates (this includes loading attribute values, attribute filters, grid columns and overall lots of bugs with them).

---------

### Requested By

##### Who reported, requested, or paid for the change?

CBCN

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/user-attachments/assets/46bd8e53-5cf4-4b5b-8d2e-949ad76d9624)

Specific changed settings:   
![image](https://github.com/user-attachments/assets/964a8c9e-946a-4bfc-86d3-bd1173c32f55)

Whole settings page screenshot:   
![image](https://github.com/user-attachments/assets/d60c3a44-c7af-47a6-afe5-1d5021f470f2)


---------

### Change Log

##### What files does it affect?

- StepsToCare/CareEntry.ascx.cs
- StepsToCare/CareDashboard.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No, but requires new DLL for new Enum's.
