### PR TITLE
New Block - Multi Group Attendance

### DIFF
--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -1,0 +1,79 @@
+﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="GroupAttendanceMulti.ascx.cs" Inherits="Plugins.rocks_kfs.Groups.GroupAttendanceMulti" %>
+<style>
+    .card-checkbox .checkbox {
+        padding-left: 0;
+    }
+
+        .card-checkbox .checkbox label {
+            width: 100%;
+        }
+
+            .card-checkbox .checkbox label .label-text:before,
+            .card-checkbox .checkbox label .label-text:after {
+                display: table;
+                content: " ";
+                border: 0;
+                position: static;
+                width: auto;
+                height: auto;
+                pointer-events: all;
+                border-radius: 0;
+                user-select: auto;
+                background: none;
+            }
+
+            .card-checkbox .checkbox label .label-text:after {
+                clear: both;
+            }
+
+            .card-checkbox .checkbox label .label-text {
+                border: solid 1px #000;
+                display: block;
+                clear: both;
+                padding: .5em;
+                border-radius: 3px;
+                width: 100%;
+            }
+
+            .card-checkbox .checkbox label input:checked + .label-text {
+                border-color: red;
+                background-color: rgba(0,0,0,0.1);
+            }
+</style>
+<asp:UpdatePanel ID="pnlContent" runat="server">
+    <ContentTemplate>
+
+        <div class="panel panel-block">
+
+            <div class="panel-heading">
+                <h1 class="panel-title pull-left">
+                    <i class="fa fa-check-square-o"></i>
+                    <asp:Literal ID="lHeading" runat="server" Text="Group Attendance" />
+                </h1>
+            </div>
+
+            <div class="panel-body">
+
+                <div class="row">
+                    <asp:Panel ID="pnlDate" runat="server" CssClass="col-sm-6">
+                        <strong>Enter Attendance For:</strong>
+                        <asp:Literal ID="lAttendanceDate" runat="server"></asp:Literal>
+                    </asp:Panel>
+                    <asp:Panel ID="pnlOther" runat="server" class="col-sm-6"></asp:Panel>
+                </div>
+                <asp:Panel ID="pnlAttendance" runat="server" CssClass="d-flex flex-wrap">
+                    <asp:Repeater ID="rptrAttendance" runat="server">
+                        <ItemTemplate>
+                            <asp:Panel ID="pnlCardCheckbox" runat="server" CssClass="card-checkbox">
+                                <Rock:RockCheckBox ID="cbAttendee" runat="server" CssClass="attendeeCheckbox" />
+                            </asp:Panel>
+                        </ItemTemplate>
+                    </asp:Repeater>
+                </asp:Panel>
+
+            </div>
+
+        </div>
+
+    </ContentTemplate>
+</asp:UpdatePanel>

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -27,7 +27,10 @@
             }
 
             .card-checkbox .checkbox label .label-text {
-                border: solid 1px #000;
+                --checked-border-color: var(--color-primary,#ee7525);
+                --checked-background-color: rgba(var(--color-base-primary),0.1);
+                background-color: var(--background-color);
+                border: 1px solid var(--border-color,var(--input-border));
                 display: block;
                 clear: both;
                 padding: .5em;
@@ -35,9 +38,16 @@
                 width: 100%;
             }
 
+                .card-checkbox .checkbox label .label-text small {
+                    font-size: x-small;
+                    display: block;
+                }
+
             .card-checkbox .checkbox label input:checked + .label-text {
-                border-color: red;
-                background-color: rgba(0,0,0,0.1);
+                --border-color: var(--checked-border-color);
+                --background-color: var(--checked-background-color);
+                outline: 2px solid var(--checked-border-color);
+                outline-offset: -2px
             }
 </style>
 <asp:UpdatePanel ID="pnlContent" runat="server">
@@ -48,24 +58,35 @@
             <div class="panel-heading">
                 <h1 class="panel-title pull-left">
                     <i class="fa fa-check-square-o"></i>
-                    <asp:Literal ID="lHeading" runat="server" Text="Group Attendance" />
+                    <asp:Literal ID="lHeading" runat="server" Text="Multiple Group Attendance" />
                 </h1>
             </div>
 
             <div class="panel-body">
+                <Rock:NotificationBox ID="nbNotice" runat="server" />
+                <asp:ValidationSummary ID="ValidationSummary1" runat="server" HeaderText="Please correct the following:" CssClass="alert alert-validation" />
+                <asp:CustomValidator ID="cvAttendance" runat="server" Display="None" />
 
-                <div class="row">
+                <div class="row mb-5">
                     <asp:Panel ID="pnlDate" runat="server" CssClass="col-sm-6">
-                        <strong>Enter Attendance For:</strong>
-                        <asp:Literal ID="lAttendanceDate" runat="server"></asp:Literal>
+                        <Rock:RockLiteral ID="lAttendanceDate" runat="server" Label="Enter Attendance For" />
+                        <Rock:DatePicker ID="dpAttendanceDate" runat="server" Label="Enter Attendance For" AllowFutureDateSelection="false" Required="true" OnSelectDate="dpAttendanceDate_SelectDate" AutoPostBack="true" />
                     </asp:Panel>
-                    <asp:Panel ID="pnlOther" runat="server" class="col-sm-6"></asp:Panel>
+                    <asp:Panel ID="pnlOther" runat="server" class="col-sm-6">
+                        <Rock:RockLiteral ID="lSchedule" runat="server" Label="Schedule(s)" />
+                    </asp:Panel>
+                </div>
+                <div class="row mb-3">
+                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 col-sm-10">
+                        <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" AutoPostBack="true" Placeholder="Search"></Rock:RockTextBox>
+                    </asp:Panel>
                 </div>
                 <asp:Panel ID="pnlAttendance" runat="server" CssClass="d-flex flex-wrap">
                     <asp:Repeater ID="rptrAttendance" runat="server">
                         <ItemTemplate>
+                            <asp:HiddenField ID="hdnAttendeeId" runat="server" Value='<%# Eval("PersonId") %>' />
                             <asp:Panel ID="pnlCardCheckbox" runat="server" CssClass="card-checkbox">
-                                <Rock:RockCheckBox ID="cbAttendee" runat="server" CssClass="attendeeCheckbox" />
+                                <Rock:RockCheckBox ID="cbAttendee" runat="server" CssClass="attendeeCheckbox" Checked='<%# Eval("Attended") %>' OnCheckedChanged="cbAttendee_CheckedChanged" AutoPostBack="true" />
                             </asp:Panel>
                         </ItemTemplate>
                     </asp:Repeater>

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -77,9 +77,14 @@ namespace Plugins.rocks_kfs.Groups
         Key = AttributeKey.CheckboxColumnClass )]
 
     [BooleanField( "Display Group Names",
-        Description = "Display the group names in the panel title.",
+        Description = "Display the group names in the panel title. Default: Yes",
         DefaultBooleanValue = true,
         Key = AttributeKey.DisplayGroupNames )]
+
+    [BooleanField( "Allow Groups from Page Parameter",
+        Description = "Allow GroupId's to be passed in via Page Parameter 'Groups' as a comma separated list, the current user must have permission to the groups for members to display. Default: No",
+        DefaultBooleanValue = false,
+        Key = AttributeKey.AllowGroupsPageParameter )]
 
     [Rock.SystemGuid.BlockTypeGuid( "B8724DBC-F8FB-426D-9296-87A5944273B9" )]
     public partial class GroupAttendanceMulti : RockBlock
@@ -93,6 +98,7 @@ namespace Plugins.rocks_kfs.Groups
             public const string AttendeeLavaTemplate = "AttendeeLavaTemplate";
             public const string CheckboxColumnClass = "CheckboxColumnClass";
             public const string DisplayGroupNames = "DisplayGroupNames";
+            public const string AllowGroupsPageParameter = "AllowGroupsPageParameter";
         }
 
         private static class DefaultValue
@@ -114,6 +120,7 @@ namespace Plugins.rocks_kfs.Groups
         {
             public const string Date = "Date";
             public const string Occurrence = "Occurrence";
+            public const string Groups = "Groups";
         }
 
         #region Private Variables
@@ -153,7 +160,15 @@ namespace Plugins.rocks_kfs.Groups
 
             _rockContext = new RockContext();
 
+            var allowGroupsPageParameter = GetAttributeValue( AttributeKey.AllowGroupsPageParameter ).AsBoolean();
             var groupIds = GetAttributeValues( AttributeKey.GroupsToDisplay ).AsIntegerList();
+
+            var pageParamGroups = PageParameter( PageParameterKey.Groups );
+            if ( allowGroupsPageParameter && pageParamGroups.IsNotNullOrWhiteSpace() )
+            {
+                groupIds = pageParamGroups.Split( ',' ).AsIntegerList();
+            }
+
             _groups = new GroupService( _rockContext ).GetByIds( groupIds ).ToList();
 
             foreach ( var group in _groups )

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -17,13 +17,15 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Entity;
 using System.Linq;
 using System.Web.UI.WebControls;
+
 using Rock;
 using Rock.Attribute;
 using Rock.Data;
-using Rock.Lava;
 using Rock.Model;
+using Rock.Security;
 using Rock.Web.UI;
 using Rock.Web.UI.Controls;
 
@@ -74,6 +76,11 @@ namespace Plugins.rocks_kfs.Groups
         DefaultValue = "col-xs-12 col-sm-6 col-md-3 col-lg-2",
         Key = AttributeKey.CheckboxColumnClass )]
 
+    [BooleanField( "Display Group Names",
+        Description = "Display the group names in the panel title.",
+        DefaultBooleanValue = true,
+        Key = AttributeKey.DisplayGroupNames )]
+
     [Rock.SystemGuid.BlockTypeGuid( "B8724DBC-F8FB-426D-9296-87A5944273B9" )]
     public partial class GroupAttendanceMulti : RockBlock
     {
@@ -85,23 +92,52 @@ namespace Plugins.rocks_kfs.Groups
             public const string GroupsToDisplay = "GroupsToDisplay";
             public const string AttendeeLavaTemplate = "AttendeeLavaTemplate";
             public const string CheckboxColumnClass = "CheckboxColumnClass";
+            public const string DisplayGroupNames = "DisplayGroupNames";
         }
 
         private static class DefaultValue
         {
-            public const string AttendeeLavaTemplate = @"<img src=""{{ GroupMember.Person.PhotoUrl }}"" class=""img-circle col-xs-3 p-0 mr-3 pull-left""> {{ GroupMember.Person.FullName }}";
+            public const string AttendeeLavaTemplate = @"{% comment %}
+  This is the lava template for each attendee item in the GroupAttendanceMulti block
+   Available Lava Fields:
+
+   + Person (the person from the group)
+   + Attended (whether or not the person is marked DidAttend = true)
+   + GroupMembers (the group member records for the Person)
+   + Groups (the group(s) the person is a member of)
+{% endcomment %}
+<img src=""{{ Person.PhotoUrl }}"" class=""img-circle col-xs-3 p-0 mr-3 pull-left""> {{ Person.FullName }}<br>
+<small class=""text-muted"">{{ Groups | Join:', ' }}</small>";
+        }
+
+        private static class PageParameterKey
+        {
+            public const string Date = "Date";
+            public const string Occurrence = "Occurrence";
         }
 
         #region Private Variables
 
         private RockContext _rockContext = null;
-        private bool _canView = false;
         private List<Group> _groups = new List<Group>();
         private List<GroupMember> _members = new List<GroupMember>();
+        private List<AttendanceAttendee> _attendees;
+        private DateTime? _attendanceDate = null;
 
         #endregion
 
         #region Control Methods
+
+        protected override void LoadViewState( object savedState )
+        {
+            base.LoadViewState( savedState );
+            _attendees = ViewState["Attendees"] as List<AttendanceAttendee>;
+        }
+        protected override object SaveViewState()
+        {
+            ViewState["Attendees"] = _attendees;
+            return base.SaveViewState();
+        }
 
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
@@ -113,18 +149,20 @@ namespace Plugins.rocks_kfs.Groups
 
             this.BlockUpdated += Block_BlockUpdated;
             this.AddConfigurationUpdateTrigger( pnlContent );
+            tbSearch.Attributes["onkeypress"] = $"clearTimeout(window.{tbSearch.ClientID}); window.{tbSearch.ClientID} = setTimeout('__doPostBack(\\'{tbSearch.UniqueID}\\',\\'\\')', 1000)";
 
             _rockContext = new RockContext();
 
             var groupIds = GetAttributeValues( AttributeKey.GroupsToDisplay ).AsIntegerList();
             _groups = new GroupService( _rockContext ).GetByIds( groupIds ).ToList();
 
-            foreach ( var groupId in groupIds )
+            foreach ( var group in _groups )
             {
-                _members.AddRange( new GroupMemberService( _rockContext ).GetByGroupId( groupId ).ToList() );
+                if ( group != null && ( group.IsAuthorized( Authorization.MANAGE_MEMBERS, CurrentPerson ) || group.IsAuthorized( Authorization.EDIT, CurrentPerson ) ) )
+                {
+                    _members.AddRange( group.ActiveMembers() );
+                }
             }
-
-            _canView = true;
         }
         /// <summary>
         /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
@@ -134,12 +172,32 @@ namespace Plugins.rocks_kfs.Groups
         {
             base.OnLoad( e );
 
-            pnlContent.Visible = _canView;
-
-            if ( !Page.IsPostBack && _canView )
+            if ( !Page.IsPostBack )
             {
-                BindFilter();
+                BindFields();
                 BindRepeat();
+            }
+            else
+            {
+                if ( _attendees != null )
+                {
+                    foreach ( RepeaterItem item in rptrAttendance.Items )
+                    {
+                        var hdnAttendeeId = item.FindControl( "hdnAttendeeId" ) as HiddenField;
+                        var cbAttendee = item.FindControl( "cbAttendee" ) as RockCheckBox;
+
+                        if ( hdnAttendeeId != null && cbAttendee != null )
+                        {
+                            int personId = hdnAttendeeId.ValueAsInt();
+
+                            var attendance = _attendees.Where( a => a.PersonId == personId ).FirstOrDefault();
+                            if ( attendance != null )
+                            {
+                                attendance.Attended = cbAttendee.Checked;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -154,56 +212,289 @@ namespace Plugins.rocks_kfs.Groups
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void Block_BlockUpdated( object sender, EventArgs e )
         {
-            BindFilter();
+            BindFields();
             BindRepeat();
         }
 
+        /// <summary>
+        /// Handles the SelectDate event of the dpAttendanceDate control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void dpAttendanceDate_SelectDate( object sender, EventArgs e )
+        {
+            BindFields();
+            BindRepeat();
+        }
+
+        /// <summary>
+        /// Handles the TextChanged event of the tbSearch control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void tbSearch_TextChanged( object sender, EventArgs e )
+        {
+            BindFields();
+            BindRepeat();
+            tbSearch.Focus();
+        }
+
+        /// <summary>
+        /// Handles the ItemDataBound event of the RptrAttendance control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.Web.UI.WebControls.RepeaterItemEventArgs"/> instance containing the event data.</param>
         private void RptrAttendance_ItemDataBound( object sender, System.Web.UI.WebControls.RepeaterItemEventArgs e )
         {
-            var groupMember = e.Item.DataItem as GroupMember;
+            var attendee = e.Item.DataItem as AttendanceAttendee;
             var cbAttendee = e.Item.FindControl( "cbAttendee" ) as RockCheckBox;
             var pnlCardCheckbox = e.Item.FindControl( "pnlCardCheckbox" ) as Panel;
 
-            if ( groupMember != null && cbAttendee != null && pnlCardCheckbox != null )
+            if ( attendee != null && cbAttendee != null && pnlCardCheckbox != null )
             {
                 pnlCardCheckbox.AddCssClass( GetAttributeValue( AttributeKey.CheckboxColumnClass ) );
+                cbAttendee.Checked = attendee.Attended;
 
                 var lavaTemplate = GetAttributeValue( AttributeKey.AttendeeLavaTemplate );
 
                 var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
-                mergeFields.Add( "GroupMember", groupMember );
+                mergeFields.Add( "Person", _members.Where( gm => gm.PersonId == attendee.PersonId ).Select( gm => gm.Person ).FirstOrDefault() );
+                mergeFields.Add( "Attended", attendee.Attended );
+                mergeFields.Add( "GroupMembers", _members.Where( gm => attendee.GroupMemberIds.Contains( gm.Id ) ) );
+                mergeFields.Add( "Groups", _groups.Where( g => attendee.Groups.Contains( g.Id ) ) );
 
                 cbAttendee.Text = lavaTemplate.ResolveMergeFields( mergeFields );
             }
         }
 
+        /// <summary>
+        /// Handles the CheckedChanged event of the cbAttendee control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void cbAttendee_CheckedChanged( object sender, EventArgs e )
+        {
+            var cbAttendee = sender as RockCheckBox;
+
+            if ( cbAttendee != null )
+            {
+                SaveAttendance();
+            }
+        }
 
         #endregion
 
         #region Internal Methods
 
         /// <summary>
-        /// Binds the filter.
+        /// Binds the fields.
         /// </summary>
-        protected void BindFilter()
+        protected void BindFields()
         {
+            var displayGroupName = GetAttributeValue( AttributeKey.DisplayGroupNames ).AsBoolean();
+            if ( displayGroupName )
+            {
+                lHeading.Text = $"{BlockName} - {_groups.Select( g => g.Name ).JoinStringsWithCommaAnd()}";
+            }
+            else
+            {
+                lHeading.Text = BlockName;
+            }
 
+            if ( !_members.Any() )
+            {
+                nbNotice.Text = "There are no members to display for the selected group(s). Please check if you have permission to Manage Members or Edit the group(s) selected.";
+            }
+
+            _attendanceDate = PageParameter( PageParameterKey.Date ).AsDateTime() ?? PageParameter( PageParameterKey.Occurrence ).AsDateTime();
+
+            if ( _attendanceDate.HasValue )
+            {
+                lAttendanceDate.Text = _attendanceDate.ToShortDateString();
+                lAttendanceDate.Visible = true;
+                dpAttendanceDate.Visible = false;
+            }
+            else
+            {
+                dpAttendanceDate.SelectedDate = dpAttendanceDate.SelectedDate ?? RockDateTime.Now;
+                _attendanceDate = dpAttendanceDate.SelectedDate;
+                dpAttendanceDate.Visible = true;
+                lAttendanceDate.Visible = false;
+            }
+
+            lSchedule.Text = _groups.Where( g => g.Schedule != null ).ToList().Select( g => g.Schedule.FriendlyScheduleText ).JoinStrings( ", " );
         }
 
         /// <summary>
-        /// Binds the group members grid.
+        /// Binds the group members/attendees repeater.
         /// </summary>
         protected void BindRepeat()
         {
+            var attendedIds = new List<int>();
+            using ( var rockContext = new RockContext() )
+            {
+                var groupIds = _groups.Select( g => g.Id ).ToList();
+                attendedIds = new AttendanceService( rockContext )
+                    .Queryable().AsNoTracking()
+                    .Where( a =>
+                        DbFunctions.DiffDays( a.StartDateTime, _attendanceDate ) == 0 &&
+                        a.DidAttend.HasValue &&
+                        a.DidAttend.Value &&
+                        a.Occurrence != null &&
+                        groupIds.Contains( a.Occurrence.GroupId.Value ) &&
+                        a.PersonAlias != null )
+                    .Select( a => a.PersonAlias.PersonId )
+                    .Distinct()
+                    .ToList();
+            }
+            var searchParts = tbSearch.Text.ToLower().SplitDelimitedValues();
+            _attendees = _members
+                .Where( gm => tbSearch.Text.IsNullOrWhiteSpace() ||
+                      ( searchParts.Length == 1 && gm.Person.LastName.ToLower().StartsWith( searchParts[0] ) ) ||
+                      ( searchParts.Length > 1 && gm.Person.FirstName.ToLower().StartsWith( searchParts[0] ) && gm.Person.LastName.ToLower().StartsWith( searchParts[1] ) )
+                )
+                .OrderBy( gm => gm.Person.LastName )
+                                                    .ThenBy( gm => gm.Person.FirstName )
+                                                    .ThenBy( gm => gm.Group.Name )
+                                                    .GroupBy( gm => gm.PersonId )
+                                                    .Select( g => new AttendanceAttendee
+                                                    {
+                                                        PersonId = g.Key,
+                                                        GroupMemberIds = g.Select( gm => gm.Id ).ToList(),
+                                                        Attended = attendedIds.Contains( g.Key ),
+                                                        Groups = g.Select( gm => gm.GroupId ).ToList()
+                                                    } )
+                                                    .ToList();
+
             rptrAttendance.ItemDataBound += RptrAttendance_ItemDataBound;
-            rptrAttendance.DataSource = _members.OrderBy( gm => gm.Person.LastName )
-                                                .ThenBy( gm => gm.Person.FirstName )
-                                                .ThenBy( gm => gm.Group.Name );
+            rptrAttendance.DataSource = _attendees;
             rptrAttendance.DataBind();
+        }
+
+        /// <summary>
+        /// Saves the attendance.
+        /// </summary>
+        /// <returns>boolean</returns>
+        private bool SaveAttendance()
+        {
+            using ( var rockContext = new RockContext() )
+            {
+                var occurrenceService = new AttendanceOccurrenceService( rockContext );
+                var attendanceService = new AttendanceService( rockContext );
+                var personAliasService = new PersonAliasService( rockContext );
+                var occurrences = new Dictionary<string, AttendanceOccurrence>();
+
+                if ( dpAttendanceDate.Visible && dpAttendanceDate.SelectedDate.HasValue )
+                {
+                    _attendanceDate = dpAttendanceDate.SelectedDate.Value;
+                }
+                if ( !_attendanceDate.HasValue )
+                {
+                    nbNotice.Text = "You must choose a date before selecting a person to record attendance.";
+                    return false;
+                }
+                if ( _attendees != null )
+                {
+                    foreach ( var attendee in _attendees )
+                    {
+                        var attendeeGroups = _groups.Where( g => attendee.Groups.Contains( g.Id ) );
+                        foreach ( var group in attendeeGroups )
+                        {
+                            var scheduleId = group.ScheduleId;
+                            AttendanceOccurrence occurrence = null;
+
+                            var occurrenceKey = $"{group.Id}_{scheduleId}";
+
+                            if ( occurrence == null && occurrences.ContainsKey( occurrenceKey ) )
+                            {
+                                occurrence = occurrences.GetValueOrNull( occurrenceKey );
+                            }
+
+                            if ( occurrence == null && _attendanceDate.HasValue )
+                            {
+                                occurrence = occurrenceService.Get( _attendanceDate.Value.Date, group.Id, null, scheduleId );
+                            }
+
+                            if ( occurrence == null )
+                            {
+                                occurrence = new AttendanceOccurrence();
+                                occurrence.GroupId = group.Id;
+                                occurrence.ScheduleId = scheduleId;
+                                occurrence.OccurrenceDate = _attendanceDate.Value;
+                                occurrenceService.Add( occurrence );
+                            }
+
+                            var existingAttendees = occurrence.Attendees.ToList();
+
+                            int? campusId = group.CampusId;
+
+                            occurrence.Schedule = occurrence.Schedule == null && occurrence.ScheduleId.HasValue ? new ScheduleService( rockContext ).Get( occurrence.ScheduleId.Value ) : occurrence.Schedule;
+
+                            cvAttendance.IsValid = occurrence.IsValid;
+                            if ( !cvAttendance.IsValid )
+                            {
+                                cvAttendance.ErrorMessage = occurrence.ValidationResults.Select( a => a.ErrorMessage ).ToList().AsDelimited( "<br />" );
+                                return false;
+                            }
+
+                            var attendance = existingAttendees
+                                .Where( a => a.PersonAlias != null && a.PersonAlias.PersonId == attendee.PersonId )
+                                .FirstOrDefault();
+
+                            if ( attendance == null )
+                            {
+                                int? personAliasId = personAliasService.GetPrimaryAliasId( attendee.PersonId );
+                                if ( personAliasId.HasValue )
+                                {
+                                    attendance = new Attendance();
+                                    attendance.PersonAliasId = personAliasId;
+                                    attendance.CampusId = campusId;
+                                    attendance.StartDateTime = occurrence.Schedule != null && occurrence.Schedule.HasSchedule() ? occurrence.OccurrenceDate.Date.Add( occurrence.Schedule.StartTimeOfDay ) : occurrence.OccurrenceDate;
+                                    attendance.DidAttend = attendee.Attended;
+
+                                    cvAttendance.IsValid = attendance.IsValid;
+                                    if ( !cvAttendance.IsValid )
+                                    {
+                                        cvAttendance.ErrorMessage = attendance.ValidationResults.Select( a => a.ErrorMessage ).ToList().AsDelimited( "<br />" );
+                                        return false;
+                                    }
+
+                                    occurrence.Attendees.Add( attendance );
+                                }
+                            }
+                            else
+                            {
+                                attendance.DidAttend = attendee.Attended;
+                            }
+
+                            occurrences.AddOrReplace( occurrenceKey, occurrence );
+                        }
+                    }
+                    rockContext.SaveChanges();
+
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
         }
 
         #endregion
     }
 
+    [Serializable]
+    public class AttendanceAttendee
+    {
+        public int PersonId { get; set; }
 
+        public List<int> GroupMemberIds { get; set; }
+
+        public bool Attended { get; set; } = false;
+
+        public List<int> Groups { get; set; }
+
+
+    }
 }

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -1,0 +1,209 @@
+﻿// <copyright>
+// Copyright 2024 by Kingdom First Solutions
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Web.UI.WebControls;
+using Rock;
+using Rock.Attribute;
+using Rock.Data;
+using Rock.Lava;
+using Rock.Model;
+using Rock.Web.UI;
+using Rock.Web.UI.Controls;
+
+namespace Plugins.rocks_kfs.Groups
+{
+    [DisplayName( "Multiple Group Attendance" )]
+    [Category( "KFS > Groups" )]
+    [Description( "Allows you to take attendance for multiple groups at once. " )]
+
+    [CustomEnhancedListField( "Groups to Display",
+        Description = "Select the groups to display in this attendance block. You may also pass in a comma separated list of GroupId's via a PageParameter 'Groups'.",
+        ListSource = @"SELECT 
+        CASE WHEN ggpg.Name IS NOT NULL THEN
+	        CONCAT(ggpg.name, ' > ',gpg.Name,' > ',pg.Name,' > ', g.Name)
+        WHEN gpg.Name IS NOT NULL THEN
+	        CONCAT(gpg.Name,' > ',pg.Name,' > ', g.Name)
+        WHEN pg.Name IS NOT NULL THEN
+	        CONCAT(pg.Name,' > ', g.Name)
+        ELSE
+	        g.Name 
+        END as Text, g.Id as Value
+        FROM [Group] g
+            LEFT JOIN [Group] pg ON g.ParentGroupId = pg.Id
+            LEFT JOIN [Group] gpg ON pg.ParentGroupId = gpg.Id
+            LEFT JOIN [Group] ggpg ON gpg.ParentGroupId = ggpg.Id
+        WHERE g.GroupTypeId NOT IN (1,10,11,12) 
+        ORDER BY 
+            CASE WHEN ggpg.Name IS NOT NULL THEN
+	            CONCAT(ggpg.name, ' > ',gpg.Name,' > ',pg.Name,' > ', g.Name)
+            WHEN gpg.Name IS NOT NULL THEN
+	            CONCAT(gpg.Name,' > ',pg.Name,' > ', g.Name)
+            WHEN pg.Name IS NOT NULL THEN
+	            CONCAT(pg.Name,' > ', g.Name)
+            ELSE
+                g.Name 
+        END",
+        IsRequired = true,
+        Key = AttributeKey.GroupsToDisplay )]
+
+    [LavaField( "Attendee Lava Template",
+        Description = "Lava template used per attendee to customize what the appearance should look like to choose the user.",
+        IsRequired = true,
+        DefaultValue = DefaultValue.AttendeeLavaTemplate,
+        Key = AttributeKey.AttendeeLavaTemplate )]
+
+    [TextField( "Checkbox Column Class",
+        Description = "Column classes for width on various screen sizes, uses standard bootstrap 3 column classes. Default: col-xs-12 col-sm-6 col-md-3 col-lg-2",
+        DefaultValue = "col-xs-12 col-sm-6 col-md-3 col-lg-2",
+        Key = AttributeKey.CheckboxColumnClass )]
+
+    [Rock.SystemGuid.BlockTypeGuid( "B8724DBC-F8FB-426D-9296-87A5944273B9" )]
+    public partial class GroupAttendanceMulti : RockBlock
+    {
+        /// <summary>
+        /// Keys to use for Block Attributes
+        /// </summary>
+        private static class AttributeKey
+        {
+            public const string GroupsToDisplay = "GroupsToDisplay";
+            public const string AttendeeLavaTemplate = "AttendeeLavaTemplate";
+            public const string CheckboxColumnClass = "CheckboxColumnClass";
+        }
+
+        private static class DefaultValue
+        {
+            public const string AttendeeLavaTemplate = @"<img src=""{{ GroupMember.Person.PhotoUrl }}"" class=""img-circle col-xs-3 p-0 mr-3 pull-left""> {{ GroupMember.Person.FullName }}";
+        }
+
+        #region Private Variables
+
+        private RockContext _rockContext = null;
+        private bool _canView = false;
+        private List<Group> _groups = new List<Group>();
+        private List<GroupMember> _members = new List<GroupMember>();
+
+        #endregion
+
+        #region Control Methods
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Init" /> event.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnInit( EventArgs e )
+        {
+            base.OnInit( e );
+
+            this.BlockUpdated += Block_BlockUpdated;
+            this.AddConfigurationUpdateTrigger( pnlContent );
+
+            _rockContext = new RockContext();
+
+            var groupIds = GetAttributeValues( AttributeKey.GroupsToDisplay ).AsIntegerList();
+            _groups = new GroupService( _rockContext ).GetByIds( groupIds ).ToList();
+
+            foreach ( var groupId in groupIds )
+            {
+                _members.AddRange( new GroupMemberService( _rockContext ).GetByGroupId( groupId ).ToList() );
+            }
+
+            _canView = true;
+        }
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
+
+            pnlContent.Visible = _canView;
+
+            if ( !Page.IsPostBack && _canView )
+            {
+                BindFilter();
+                BindRepeat();
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Handles the BlockUpdated event of the control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        protected void Block_BlockUpdated( object sender, EventArgs e )
+        {
+            BindFilter();
+            BindRepeat();
+        }
+
+        private void RptrAttendance_ItemDataBound( object sender, System.Web.UI.WebControls.RepeaterItemEventArgs e )
+        {
+            var groupMember = e.Item.DataItem as GroupMember;
+            var cbAttendee = e.Item.FindControl( "cbAttendee" ) as RockCheckBox;
+            var pnlCardCheckbox = e.Item.FindControl( "pnlCardCheckbox" ) as Panel;
+
+            if ( groupMember != null && cbAttendee != null && pnlCardCheckbox != null )
+            {
+                pnlCardCheckbox.AddCssClass( GetAttributeValue( AttributeKey.CheckboxColumnClass ) );
+
+                var lavaTemplate = GetAttributeValue( AttributeKey.AttendeeLavaTemplate );
+
+                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
+                mergeFields.Add( "GroupMember", groupMember );
+
+                cbAttendee.Text = lavaTemplate.ResolveMergeFields( mergeFields );
+            }
+        }
+
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// Binds the filter.
+        /// </summary>
+        protected void BindFilter()
+        {
+
+        }
+
+        /// <summary>
+        /// Binds the group members grid.
+        /// </summary>
+        protected void BindRepeat()
+        {
+            rptrAttendance.ItemDataBound += RptrAttendance_ItemDataBound;
+            rptrAttendance.DataSource = _members.OrderBy( gm => gm.Person.LastName )
+                                                .ThenBy( gm => gm.Person.FirstName )
+                                                .ThenBy( gm => gm.Group.Name );
+            rptrAttendance.DataBind();
+        }
+
+        #endregion
+    }
+
+
+}

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -163,7 +163,7 @@
                                     Total Care Needs
                                 </a>
                             </li>
-                            <li class="block-status care-enter-need">
+                            <li class="block-status care-enter-need" id="liEnterNeed" runat="server">
                                 <asp:LinkButton ID="btnAdd" runat="server" CssClass="btn btn-default" OnClick="gList_AddClick"><i class='fas fa-plus'></i><strong class="text-uppercase">Enter Care Need</strong></asp:LinkButton>
                             </li>
                             <li class="block-status care-categories">

--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -358,6 +358,8 @@
                     <asp:Panel ID="pnlQuickNoteText" runat="server" CssClass="noteentry-control meta-body" Visible="false">
                         <Rock:RockTextBox ID="rtbNote" runat="server" Placeholder="Write an additional note..." Rows="3" TextMode="MultiLine" ValidationGroup="QuickNoteMakeNote"></Rock:RockTextBox>
                         <div class="settings clearfix">
+                            <asp:Checkbox ID="cbAlert" runat="server" Text="Alert" CssClass="js-notealert" />
+                            <asp:Checkbox ID="cbPrivate" runat="server" Text="Private" CssClass="js-noteprivate" />
                             <Rock:BootstrapButton ID="rbBtnQuickNoteSave" runat="server" DataLoadingText="Saving..." Text="Save Note" CssClass="commands btn btn-primary btn-xs" OnClick="rbBtnQuickNoteSave_Click" ValidationGroup="QuickNoteMakeNote"></Rock:BootstrapButton>
                         </div>
                     </asp:Panel>

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2159,6 +2159,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 foreach ( var attribute in AvailableAttributes )
                 {
                     var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
+                    var controlFollowUp = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_followup_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
                     if ( control != null )
                     {
                         if ( control is IRockControl )
@@ -2167,7 +2168,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             rockControl.Label = attribute.Name;
                             rockControl.Help = attribute.Description;
                             phAttributeFilters.Controls.Add( control );
-                            phFollowUpAttributeFilters.Controls.Add( control );
                         }
                         else
                         {
@@ -2175,6 +2175,39 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             wrapper.ID = control.ID + "_wrapper";
                             wrapper.Label = attribute.Name;
                             wrapper.Controls.Add( control );
+                            phAttributeFilters.Controls.Add( wrapper );
+                        }
+
+                        string savedValue = rFilter.GetUserPreference( attribute.Key );
+                        if ( !string.IsNullOrWhiteSpace( savedValue ) )
+                        {
+                            try
+                            {
+                                var values = JsonConvert.DeserializeObject<List<string>>( savedValue );
+                                attribute.FieldType.Field.SetFilterValues( control, attribute.QualifierValues, values );
+                            }
+                            catch
+                            {
+                                // intentionally ignore
+                            }
+                        }
+                    }
+                    if ( controlFollowUp != null )
+                    {
+                        if ( controlFollowUp is IRockControl )
+                        {
+                            var rockControl = ( IRockControl ) controlFollowUp;
+                            rockControl.Label = attribute.Name;
+                            rockControl.Help = attribute.Description;
+                            phAttributeFilters.Controls.Add( controlFollowUp );
+                            phFollowUpAttributeFilters.Controls.Add( controlFollowUp );
+                        }
+                        else
+                        {
+                            var wrapper = new RockControlWrapper();
+                            wrapper.ID = controlFollowUp.ID + "_wrapper";
+                            wrapper.Label = attribute.Name;
+                            wrapper.Controls.Add( controlFollowUp );
                             phAttributeFilters.Controls.Add( wrapper );
                             phFollowUpAttributeFilters.Controls.Add( wrapper );
                         }
@@ -2185,7 +2218,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             try
                             {
                                 var values = JsonConvert.DeserializeObject<List<string>>( savedValue );
-                                attribute.FieldType.Field.SetFilterValues( control, attribute.QualifierValues, values );
+                                attribute.FieldType.Field.SetFilterValues( controlFollowUp, attribute.QualifierValues, values );
                             }
                             catch
                             {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2534,6 +2534,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( cn => cn.AssignedPersons.Count( ap => ap.PersonAliasId == CurrentPersonAliasId ) > 0 );
             }
 
+            // Filter query by any configured attribute filters
+            if ( AvailableAttributes != null && AvailableAttributes.Any() )
+            {
+                foreach ( var attribute in AvailableAttributes )
+                {
+                    var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
+                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
+                }
+            }
+
             SortProperty sortProperty = gList.SortProperty;
             if ( sortProperty != null )
             {
@@ -2565,16 +2575,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     .ThenByDescending( a => a.DateEntered )
                     .ThenBy( a => a.ParentNeedId )
                     .ThenByDescending( a => a.Id );
-            }
-
-            // Filter query by any configured attribute filters
-            if ( AvailableAttributes != null && AvailableAttributes.Any() )
-            {
-                foreach ( var attribute in AvailableAttributes )
-                {
-                    var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
-                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
-                }
             }
 
             var list = qry.ToList();
@@ -2691,6 +2691,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( cn => cn.AssignedPersons.Count( ap => ap.PersonAliasId == CurrentPersonAliasId ) > 0 );
             }
 
+            // Filter query by any configured attribute filters
+            if ( AvailableAttributes != null && AvailableAttributes.Any() )
+            {
+                foreach ( var attribute in AvailableAttributes )
+                {
+                    var filterControl = phFollowUpAttributeFilters.FindControl( "filter_followup_" + attribute.Id.ToString() );
+                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
+                }
+            }
+
             SortProperty sortProperty = gFollowUp.SortProperty;
             if ( sortProperty != null )
             {
@@ -2717,16 +2727,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             else
             {
                 qry = qry.OrderByDescending( a => a.DateEntered ).ThenByDescending( a => a.Id );
-            }
-
-            // Filter query by any configured attribute filters
-            if ( AvailableAttributes != null && AvailableAttributes.Any() )
-            {
-                foreach ( var attribute in AvailableAttributes )
-                {
-                    var filterControl = phFollowUpAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
-                    qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careNeedService, Rock.Reporting.FilterMode.SimpleFilter );
-                }
             }
 
             var list = qry.ToList();

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -82,6 +82,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
         Order = 4,
         Key = AttributeKey.MinimumCareTouchHours )]
 
+    [BooleanField( "Enter Care Need Edit Permission",
+        Description = "Should the \"Enter Care Need\" large button be protected by the edit permission?",
+        DefaultBooleanValue = false,
+        Order = 5,
+        Key = AttributeKey.EnterCareNeed )]
+
     [DefinedValueField(
         "Outstanding Care Needs Statuses",
         Description = "Select the status values that count towards the 'Outstanding Care Needs' total.",
@@ -331,6 +337,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             public const string TouchNeededTooltipTemplate = "TouchNeededTooltipTemplate";
             public const string QuickNoteStatusTemplate = "QuickNoteStatusTemplate";
             public const string QuickNoteAutoSave = "QuickNoteAutoSave";
+            public const string EnterCareNeed = "EnterCareNeed";
         }
 
         /// <summary>
@@ -600,6 +607,9 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             gFollowUp.Actions.ShowAdd = false;
             gFollowUp.Actions.ShowMergeTemplate = false;
             gFollowUp.IsDeleteEnabled = _canAdministrate;
+
+            var enterCareNeedEditPermission = GetAttributeValue( AttributeKey.EnterCareNeed ).AsBoolean();
+            liEnterNeed.Visible = _canEdit || !enterCareNeedEditPermission;
 
             mdMakeNote.Footer.Visible = false;
 

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -2008,7 +2008,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 var closeDialogOnSave = GetAttributeValue( AttributeKey.CloseDialogOnSave ).AsBoolean();
                 var careNeedId = hfCareNeedId.ValueAsInt();
 
-                var noteCreated = createNote( rockContext, careNeedId, $"{noteTemplate.Note}{( rtbNote.Text.IsNotNullOrWhiteSpace() ? ":" : "" )} {rtbNote.Text}", closeDialogOnSave, noteTemplate, true );
+                var noteCreated = createNote( rockContext, careNeedId, $"{noteTemplate.Note}{( rtbNote.Text.IsNotNullOrWhiteSpace() ? ":" : "" )} {rtbNote.Text}", closeDialogOnSave, noteTemplate, true, cbAlert.Checked, cbPrivate.Checked );
                 if ( noteCreated )
                 {
                     if ( GetAttributeValue( AttributeKey.MoveNeedToSnoozed ).AsBoolean() )
@@ -2776,13 +2776,18 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             notesTimeline.AllowAnonymousEntry = false;
             notesTimeline.SortDirection = ListSortDirection.Descending;
 
+            cbAlert.Visible = noteOptions.ShowAlertCheckBox;
+            cbAlert.Checked = false;
+            cbPrivate.Visible = noteOptions.ShowPrivateCheckBox;
+            cbPrivate.Checked = false;
+
             var noteEditor = ( NoteEditor ) notesTimeline.Controls[0];
             noteEditor.CssClass = "note-new-kfs";
             noteEditor.SaveButtonClick += mdMakeNote_SaveClick;
             noteEditor.Focus();
         }
 
-        private bool createNote( RockContext rockContext, int entityId, string noteText, bool displayDialog = false, NoteTemplate noteTemplate = null, bool countsForTouch = false )
+        private bool createNote( RockContext rockContext, int entityId, string noteText, bool displayDialog = false, NoteTemplate noteTemplate = null, bool countsForTouch = false, bool isAlert = false, bool isPrivate = false )
         {
             var noteService = new NoteService( rockContext );
             var noteType = _careNeedNoteTypes.FirstOrDefault();
@@ -2794,7 +2799,8 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 {
                     Id = 0,
                     IsSystem = false,
-                    IsAlert = false,
+                    IsAlert = isAlert,
+                    IsPrivateNote = isPrivate,
                     NoteTypeId = noteType.Id,
                     EntityId = entityId,
                     Text = noteText,

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -1044,7 +1044,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             {
                                 var careNeedNotes = new NoteService( rockContext )
                                     .GetByNoteTypeId( noteType.Id ).AsNoTracking()
-                                    .Where( n => n.EntityId == careNeed.Id && !n.Caption.StartsWith( "Action" ) );
+                                    .Where( n => n.EntityId == careNeed.Id && ( n.Caption == null || !n.Caption.StartsWith( "Action" ) ) );
                                 careNeedNotesList = careNeedNotes.ToList();
 
                                 lCareTouches.Text = careNeedNotes.Count().ToString();
@@ -2316,7 +2316,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var currentDateTime = RockDateTime.Now;
                 var last7Days = currentDateTime.AddDays( -7 );
-                var careTouches = noteQry.Count( n => n.CreatedDateTime >= last7Days && n.CreatedDateTime <= currentDateTime && !n.Caption.StartsWith( "Action" ) );
+                var careTouches = noteQry.Count( n => n.CreatedDateTime >= last7Days && n.CreatedDateTime <= currentDateTime && ( n.Caption == null || !n.Caption.StartsWith( "Action" ) ) );
 
                 lTouchesCount.Text = careTouches.ToString();
                 lCareNeedsCount.Text = outstandingCareNeeds.ToString();
@@ -3021,7 +3021,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 var lavaTemplate = GetAttributeValue( AttributeKey.QuickNoteStatusTemplate );
 
-                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson, new Rock.Lava.CommonMergeFieldsOptions { GetLegacyGlobalMergeFields = false } );
+                var mergeFields = Rock.Lava.LavaHelper.GetCommonMergeFields( this.RockPage, this.CurrentPerson );
                 mergeFields.Add( "CareNeed", careNeed );
                 mergeFields.Add( "TouchTemplates", catTouchTemplates );
                 mergeFields.Add( "CareNeedNotes", careNeedNotesList.Where( n => n.Caption == null || ( n.Caption != null && !n.Caption.StartsWith( "Action" ) ) ) );

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -895,6 +895,25 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             returnStr = typeQualifierArray[2];
                         }
                     }
+                    else if ( assignedPerson.Type == AssignedType.TouchTemplateGroup && typeQualifierArray.Length > 1 )
+                    {
+                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+
+                        if ( typeQualifierArray.Length > 4 )
+                        {
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]}";
+                        }
+                        else
+                        {
+                            returnStr = $"Touch Template Group: {typeQualifierArray[1]}";
+                        }
+                    }
+                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 4 )
+                    {
+                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+
+                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]}";
+                    }
                 }
                 phCountOrRole.Controls.Add( new LiteralControl( returnStr ) );
             }

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -897,22 +897,26 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     }
                     else if ( assignedPerson.Type == AssignedType.TouchTemplateGroup && typeQualifierArray.Length > 1 )
                     {
-                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+                        // format is [0]TouchTemplate.NoteTemplate.Note^[1]TouchTemplate.MinimumCareTouches^[2]GroupId^[3]Group Name^[4]GroupMember.Id^[5]Assigned Count
 
-                        if ( typeQualifierArray.Length > 4 )
+                        if ( typeQualifierArray.Length > 5 )
                         {
-                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]}";
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
+                        }
+                        else if ( typeQualifierArray.Length > 4 )
+                        {
+                            returnStr = $"{typeQualifierArray[0]} Touch Template Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
                         }
                         else
                         {
                             returnStr = $"Touch Template Group: {typeQualifierArray[1]}";
                         }
                     }
-                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 4 )
+                    else if ( assignedPerson.Type == AssignedType.CategoryGroup && typeQualifierArray.Length > 5 )
                     {
-                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id
+                        // format is [0]Category Value Id^[1]Category Value^[2]GroupId^[3]Group Name^[4]GroupMember.Id^[5]Assigned Count
 
-                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]}";
+                        returnStr = $"{typeQualifierArray[1]} Category Group: {typeQualifierArray[3]} ({typeQualifierArray[5]})";
                     }
                 }
                 phCountOrRole.Controls.Add( new LiteralControl( returnStr ) );

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -247,15 +247,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             btnComplete.Text = btnCompleteFtr.Text = GetAttributeValue( AttributeKey.CompleteButtonText );
             btnSnooze.Text = btnSnoozeFtr.Text = GetAttributeValue( AttributeKey.SnoozedButtonText );
             cbCustomFollowUp.Visible = GetAttributeValue( AttributeKey.EnableCustomFollowUp ).AsBoolean();
-        }
-
-        /// <summary>
-        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
-        /// </summary>
-        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
-        protected override void OnLoad( EventArgs e )
-        {
-            base.OnLoad( e );
 
             if ( !Page.IsPostBack )
             {
@@ -268,13 +259,22 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 CareNeed item = new CareNeedService( rockContext ).Get( hfCareNeedId.ValueAsInt() );
                 if ( item == null )
                 {
-                    item = new CareNeed();
+                    item = GenerateTempNeed( null );
                 }
                 item.LoadAttributes();
 
                 phAttributes.Controls.Clear();
                 Helper.AddEditControls( item, phAttributes, false, BlockValidationGroup, 2 );
             }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:System.Web.UI.Control.Load" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="T:System.EventArgs" /> object that contains the event data.</param>
+        protected override void OnLoad( EventArgs e )
+        {
+            base.OnLoad( e );
 
             confirmExit.Enabled = true;
         }
@@ -1327,7 +1327,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 AssignedPersons = CareUtilities.AutoAssignWorkers( careNeed, cbWorkersOnly.Checked, autoAssignWorker: autoAssignWorker, autoAssignWorkerGeofence: autoAssignWorkerGeofence, loadBalanceType: loadBalanceType, enableLogging: enableLogging, leaderRoleGuids: leaderRoleGuids, previewAssigned: previewAssignedPeople );
                 pwAssigned.Visible = UserCanAdministrate;
-                BindAssignedPersonsGrid();
+                BindAssignedPersonsGrid( true );
             }
             else if ( needId == 0 )
             {
@@ -1335,10 +1335,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 pwAssigned.Visible = false;
                 AssignedPersons = null;
-            }
-            else
-            {
-                GenerateTempNeed( null, categoryId );
             }
         }
 
@@ -1348,17 +1344,27 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             {
                 categoryId = dvpCategory.SelectedValue.AsIntegerOrNull();
             }
+            if ( categoryId == null )
+            {
+                categoryId = Request.Form[dvpCategory.UniqueID].AsIntegerOrNull();
+            }
+            var campusId = cpCampus.SelectedCampusId;
+            if ( campusId == null )
+            {
+                campusId = Request.Form[cpCampus.UniqueID].AsIntegerOrNull();
+            }
+            int? statusId = dvpStatus.SelectedValue.AsIntegerOrNull();
+            if ( statusId == null )
+            {
+                statusId = Request.Form[dvpStatus.UniqueID].AsIntegerOrNull();
+            }
+
             var careNeed = new CareNeed { Id = 0 };
             careNeed.CampusId = cpCampus.SelectedCampusId;
             careNeed.PersonAlias = person?.PrimaryAlias;
             careNeed.PersonAliasId = person?.PrimaryAliasId;
-            careNeed.StatusValueId = dvpStatus.SelectedValue.AsIntegerOrNull();
+            careNeed.StatusValueId = statusId;
             careNeed.CategoryValueId = categoryId;
-
-            careNeed.LoadAttributes();
-
-            phAttributes.Controls.Clear();
-            Helper.AddEditControls( careNeed, phAttributes, false, BlockValidationGroup, 2 );
 
             return careNeed;
         }

--- a/StepsToCare/CareNoteTemplates.ascx.cs
+++ b/StepsToCare/CareNoteTemplates.ascx.cs
@@ -153,7 +153,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             // Parse the attribute filters
             AvailableAttributes = new List<AttributeCache>();
 
-            int entityTypeId = new CareNeed().TypeId;
+            int entityTypeId = new NoteTemplate().TypeId;
             foreach ( var attributeModel in new AttributeService( new RockContext() ).Queryable()
                 .Where( a =>
                     a.EntityTypeId == entityTypeId &&
@@ -350,6 +350,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             tbNote.Text = noteTemplate.Note;
 
             noteTemplate.LoadAttributes();
+            phAttributes.Controls.Clear();
             Helper.AddEditControls( noteTemplate, phAttributes, true, BlockValidationGroup, 2 );
 
             hfNoteTemplateId.Value = noteTemplate.Id.ToString();
@@ -372,9 +373,11 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     noteTemplate = noteTemplateService.Get( noteTemplateId );
                 }
 
+                NoteTemplate lastNoteTemplate = null;
                 if ( noteTemplate == null )
                 {
                     noteTemplate = new NoteTemplate { Id = 0 };
+                    lastNoteTemplate = noteTemplateService.Queryable().OrderByDescending( b => b.Order ).FirstOrDefault();
                 }
 
                 noteTemplate.Icon = tbIcon.Text;
@@ -383,13 +386,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 
                 noteTemplate.IsActive = cbActive.Checked;
 
-                NoteTemplate lastNoteTemplate = noteTemplateService.Queryable().OrderByDescending( b => b.Order ).FirstOrDefault();
 
                 if ( lastNoteTemplate != null )
                 {
                     noteTemplate.Order = lastNoteTemplate.Order + 1;
                 }
-                else
+                else if ( noteTemplate.Id == 0 )
                 {
                     noteTemplate.Order = 0;
                 }

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -440,16 +440,6 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 qry = qry.Where( b => b.CategoryValues.Contains( categoryValueId.ToString() ) );
             }
 
-            SortProperty sortProperty = gList.SortProperty;
-            if ( sortProperty != null )
-            {
-                qry = qry.Sort( sortProperty );
-            }
-            else
-            {
-                qry = qry.OrderBy( cw => cw.PersonAlias.Person.LastName ).ThenBy( cw => cw.PersonAlias.Person.FirstName ).ThenByDescending( cw => cw.Id );
-            }
-
             // Filter query by any configured attribute filters
             if ( AvailableAttributes != null && AvailableAttributes.Any() )
             {
@@ -458,6 +448,16 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                     var filterControl = phAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
                     qry = attribute.FieldType.Field.ApplyAttributeQueryFilter( qry, filterControl, attribute, careWorkerService, Rock.Reporting.FilterMode.SimpleFilter );
                 }
+            }
+
+            SortProperty sortProperty = gList.SortProperty;
+            if ( sortProperty != null )
+            {
+                qry = qry.Sort( sortProperty );
+            }
+            else
+            {
+                qry = qry.OrderBy( cw => cw.PersonAlias.Person.LastName ).ThenBy( cw => cw.PersonAlias.Person.FirstName ).ThenByDescending( cw => cw.Id );
             }
 
             var list = qry.ToList();

--- a/StepsToCare/CareWorkers.ascx.cs
+++ b/StepsToCare/CareWorkers.ascx.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 by Kingdom First Solutions
+// Copyright 2024 by Kingdom First Solutions
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             // Parse the attribute filters
             AvailableAttributes = new List<AttributeCache>();
 
-            int entityTypeId = new CareNeed().TypeId;
+            int entityTypeId = new CareWorker().TypeId;
             foreach ( var attributeModel in new AttributeService( new RockContext() ).Queryable()
                 .Where( a =>
                     a.EntityTypeId == entityTypeId &&
@@ -559,6 +559,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
             }
 
             careWorker.LoadAttributes();
+            phAttributes.Controls.Clear();
             Helper.AddEditControls( careWorker, phAttributes, true, BlockValidationGroup, 2 );
 
             ppPerson_SelectPerson( null, null );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added new block for Multiple Group Attendance.

**New Settings:**

- _Name_, the block name controls the panel title.
- _Attendee Lava Template_, Lava template used per attendee to customize what the appearance should look like to choose the user.
- _Checkbox Column Class_, Column classes for width on various screen sizes, uses standard bootstrap 3 column classes. Default: col-xs-12 col-sm-6 col-md-3 col-lg-2
- _Display Group Names_, Display the group names in the panel title.
- _Groups to Display_, Select the groups to display in this attendance block. You may also pass in a comma separated list of GroupId's via a PageParameter 'Groups'.
- _Allow Groups from Page Parameter_, Allow GroupId's to be passed in via Page Parameter 'Groups' as a comma separated list, the current user must have permission to the groups for members to display. Default: No

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Added new block for simplified multiple group attendance entry.

---------

### Requested By

##### Who reported, requested, or paid for the change?

ADA

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/user-attachments/assets/8acf132c-e21e-4bbf-a553-9d645deef907)

![image](https://github.com/user-attachments/assets/a51ed41e-9fcb-42de-ad6c-6be5259b62fc)

---------

### Change Log

##### What files does it affect?

- Groups/GroupAttendanceMulti.ascx
- Groups/GroupAttendanceMulti.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No (though it was branched off of #179 so that needs to be accepted first.)
