### PR TITLE
Multi Group Attendance Updates

### DIFF
--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -12,6 +12,12 @@
         }
     }
 
+    .kfs-add-person {
+        width: calc(100% - 22px);
+        display: inline-block;
+        margin-right: 6px;
+    }
+
     .card-checkbox .checkbox {
         padding-left: 0;
     }
@@ -91,15 +97,16 @@
                     </asp:Panel>
                 </div>
                 <div class="row mb-3">
-                    <asp:Panel ID="pnlCount" runat="server" CssClass="col-xs-12 col-sm-3 col-md-2 col-sm-push-9 col-md-push-10 text-center" style="line-height: 38px;">
+                    <asp:Panel ID="pnlCount" runat="server" CssClass="col-xs-12 col-sm-3 col-md-2 col-sm-push-9 col-md-push-10 text-center" Style="line-height: 38px;">
                         <strong><asp:Literal ID="lCount" runat="server" /></strong> Attended
                     </asp:Panel>
-                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 pb-2 pb-sm-0 col-sm-6 col-md-7 col-sm-pull-3 col-md-pull-2">
+                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 pb-2 pb-sm-0 col-sm-5 col-md-5 col-sm-pull-3 col-md-pull-2">
                         <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search"></Rock:RockTextBox>
                     </asp:Panel>
-                    <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-4 col-md-3 col-sm-pull-3 col-md-pull-2">
-                        <Rock:PersonPicker ID="ppAddPerson" runat="server" OnSelectPerson="ppAddPerson_SelectPerson" />
+                    <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-4 col-md-5 col-sm-pull-3 col-md-pull-2">
                         <Rock:RockDropDownList ID="ddlAddPersonGroup" runat="server" OnSelectedIndexChanged="ddlAddPersonGroup_SelectedIndexChanged" AutoPostBack="true"></Rock:RockDropDownList>
+                        <Rock:PersonPicker ID="ppAddPerson" runat="server" CssClass="kfs-add-person" OnSelectPerson="ppAddPerson_SelectPerson" />
+                        <asp:LinkButton ID="lbClearPerson" runat="server" OnClick="lbClearPerson_Click" CssClass="text-gray-500"><i class="fa fa-times"></i></asp:LinkButton>
                     </asp:Panel>
                 </div>
                 <div class="row mb-3 bg-white position-sticky-top" runat="server" id="divLastnameButtonRow">

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -3,6 +3,13 @@
     .position-sticky-top {
         position: sticky;
         top: 0;
+        z-index: 1001;
+    }
+
+    @media screen and (min-width: 991px) {
+        .position-sticky-top {
+            top: 80px;
+        }
     }
 
     .card-checkbox .checkbox {
@@ -92,7 +99,7 @@
                         <Rock:RockDropDownList ID="ddlAddPersonGroup" runat="server" OnSelectedIndexChanged="ddlAddPersonGroup_SelectedIndexChanged" AutoPostBack="true"></Rock:RockDropDownList>
                     </asp:Panel>
                 </div>
-                <div class="row mb-3 position-sticky-top" runat="server" id="divLastnameButtonRow">
+                <div class="row mb-3 bg-white position-sticky-top" runat="server" id="divLastnameButtonRow">
                     <asp:Panel runat="server" ID="lastnameButtons" CssClass="col-xs-12 table-responsive">
                         <div class="btn-group d-flex">
                             <a href="#lastnameA" class="btn btn-lg btn-default">A</a>

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -1,5 +1,10 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeFile="GroupAttendanceMulti.ascx.cs" Inherits="Plugins.rocks_kfs.Groups.GroupAttendanceMulti" %>
 <style>
+    .position-sticky-top {
+        position: sticky;
+        top: 0;
+    }
+
     .card-checkbox .checkbox {
         padding-left: 0;
     }
@@ -83,9 +88,43 @@
                         <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search"></Rock:RockTextBox>
                     </asp:Panel>
                 </div>
+                <div class="row mb-3 position-sticky-top" runat="server" id="divLastnameButtonRow">
+                    <asp:Panel runat="server" ID="lastnameButtons" CssClass="col-xs-12 table-responsive">
+                        <div class="btn-group d-flex">
+                            <a href="#lastnameA" class="btn btn-lg btn-default">A</a>
+                            <a href="#lastnameB" class="btn btn-lg btn-default">B</a>
+                            <a href="#lastnameC" class="btn btn-lg btn-default">C</a>
+                            <a href="#lastnameD" class="btn btn-lg btn-default">D</a>
+                            <a href="#lastnameE" class="btn btn-lg btn-default">E</a>
+                            <a href="#lastnameF" class="btn btn-lg btn-default">F</a>
+                            <a href="#lastnameG" class="btn btn-lg btn-default">G</a>
+                            <a href="#lastnameH" class="btn btn-lg btn-default">H</a>
+                            <a href="#lastnameI" class="btn btn-lg btn-default">I</a>
+                            <a href="#lastnameJ" class="btn btn-lg btn-default">J</a>
+                            <a href="#lastnameK" class="btn btn-lg btn-default">K</a>
+                            <a href="#lastnameL" class="btn btn-lg btn-default">L</a>
+                            <a href="#lastnameM" class="btn btn-lg btn-default">M</a>
+                            <a href="#lastnameN" class="btn btn-lg btn-default">N</a>
+                            <a href="#lastnameO" class="btn btn-lg btn-default">O</a>
+                            <a href="#lastnameP" class="btn btn-lg btn-default">P</a>
+                            <a href="#lastnameQ" class="btn btn-lg btn-default">Q</a>
+                            <a href="#lastnameR" class="btn btn-lg btn-default">R</a>
+                            <a href="#lastnameS" class="btn btn-lg btn-default">S</a>
+                            <a href="#lastnameT" class="btn btn-lg btn-default">T</a>
+                            <a href="#lastnameU" class="btn btn-lg btn-default">U</a>
+                            <a href="#lastnameV" class="btn btn-lg btn-default">V</a>
+                            <a href="#lastnameW" class="btn btn-lg btn-default">W</a>
+                            <a href="#lastnameX" class="btn btn-lg btn-default">X</a>
+                            <a href="#lastnameY" class="btn btn-lg btn-default">Y</a>
+                            <a href="#lastnameZ" class="btn btn-lg btn-default">Z</a>
+                        </div>
+                    </asp:Panel>
+                </div>
                 <asp:Panel ID="pnlAttendance" runat="server" CssClass="d-flex flex-wrap">
+                    <a name='lastnameA' id='lastnameA'></a>
                     <asp:Repeater ID="rptrAttendance" runat="server">
                         <ItemTemplate>
+                            <asp:Literal ID="lAnchor" runat="server" />
                             <asp:HiddenField ID="hdnAttendeeId" runat="server" Value='<%# Eval("PersonId") %>' />
                             <asp:Panel ID="pnlCardCheckbox" runat="server" CssClass="card-checkbox">
                                 <Rock:RockCheckBox ID="cbAttendee" runat="server" CssClass="attendeeCheckbox" Checked='<%# Eval("Attended") %>' OnCheckedChanged="cbAttendee_CheckedChanged" AutoPostBack="true" />

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -84,8 +84,12 @@
                     </asp:Panel>
                 </div>
                 <div class="row mb-3">
-                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 col-sm-10">
+                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 col-sm-9">
                         <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search"></Rock:RockTextBox>
+                    </asp:Panel>
+                    <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-3">
+                        <Rock:PersonPicker ID="ppAddPerson" runat="server" OnSelectPerson="ppAddPerson_SelectPerson" />
+                        <Rock:RockDropDownList ID="ddlAddPersonGroup" runat="server" OnSelectedIndexChanged="ddlAddPersonGroup_SelectedIndexChanged" AutoPostBack="true"></Rock:RockDropDownList>
                     </asp:Panel>
                 </div>
                 <div class="row mb-3 position-sticky-top" runat="server" id="divLastnameButtonRow">

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -91,10 +91,13 @@
                     </asp:Panel>
                 </div>
                 <div class="row mb-3">
-                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 col-sm-9">
+                    <asp:Panel ID="pnlCount" runat="server" CssClass="col-xs-12 col-sm-3 col-md-2 col-sm-push-9 col-md-push-10 text-center" style="line-height: 38px;">
+                        <strong><asp:Literal ID="lCount" runat="server" /></strong> Attended
+                    </asp:Panel>
+                    <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 pb-2 pb-sm-0 col-sm-6 col-md-7 col-sm-pull-3 col-md-pull-2">
                         <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search"></Rock:RockTextBox>
                     </asp:Panel>
-                    <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-3">
+                    <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-4 col-md-3 col-sm-pull-3 col-md-pull-2">
                         <Rock:PersonPicker ID="ppAddPerson" runat="server" OnSelectPerson="ppAddPerson_SelectPerson" />
                         <Rock:RockDropDownList ID="ddlAddPersonGroup" runat="server" OnSelectedIndexChanged="ddlAddPersonGroup_SelectedIndexChanged" AutoPostBack="true"></Rock:RockDropDownList>
                     </asp:Panel>

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -592,20 +592,20 @@ namespace Plugins.rocks_kfs.Groups
             }
 
             var searchParts = tbSearch.Text.ToLower().SplitDelimitedValues();
-            _attendees = _attendees.Where( gm => tbSearch.Text.IsNullOrWhiteSpace() ||
-                                          ( searchParts.Length == 1 && gm.LastName.ToLower().StartsWith( searchParts[0] ) ) ||
-                                          ( searchParts.Length > 1 && ( gm.FirstName.ToLower().StartsWith( searchParts[0] ) ||
-                                                                        gm.NickName.ToLower().StartsWith( searchParts[0] )
-                                                                      ) && gm.LastName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
+            _attendees = _attendees.Where( a => tbSearch.Text.IsNullOrWhiteSpace() ||
+                                          ( searchParts.Length == 1 && a.LastName.ToLower().StartsWith( searchParts[0] ) ) ||
+                                          ( searchParts.Length > 1 && ( a.FirstName.ToLower().StartsWith( searchParts[0] ) ||
+                                                                        a.NickName.ToLower().StartsWith( searchParts[0] )
+                                                                      ) && a.LastName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
                                           ) ||
-                                          ( searchParts.Length > 1 && ( gm.FirstName.ToLower().StartsWith( searchParts[searchParts.Length - 1] ) ||
-                                                                        gm.NickName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
-                                                                      ) && gm.LastName.ToLower().StartsWith( searchParts[0] )
+                                          ( searchParts.Length > 1 && ( a.FirstName.ToLower().StartsWith( searchParts[searchParts.Length - 1] ) ||
+                                                                        a.NickName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
+                                                                      ) && a.LastName.ToLower().StartsWith( searchParts[0] )
                                           )
                                     )
-                                    .OrderBy( gm => gm.LastName )
-                                    .ThenBy( gm => gm.FirstName )
-                                    .ThenBy( gm => gm.GroupName )
+                                    .OrderBy( a => a.LastName )
+                                    .ThenBy( a => a.FirstName )
+                                    .ThenBy( a => a.GroupName )
                                     .ToList();
 
             lCount.Text = _attendees.Count( a => a.Attended ).ToString();
@@ -717,6 +717,8 @@ namespace Plugins.rocks_kfs.Groups
                         }
                     }
                     rockContext.SaveChanges();
+
+                    lCount.Text = _attendees.Count( a => a.Attended ).ToString();
 
                     return true;
                 }

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -573,6 +573,8 @@ namespace Plugins.rocks_kfs.Groups
                                     .ThenBy( gm => gm.GroupName )
                                     .ToList();
 
+            lCount.Text = _attendees.Count( a => a.Attended ).ToString();
+
             rptrAttendance.ItemDataBound += RptrAttendance_ItemDataBound;
             rptrAttendance.DataSource = _attendees;
             rptrAttendance.DataBind();


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added LastName buttons to jump down in long lists.
- Added ability to add an attendee to specific occurrence for a specific group.
- Added new setting to combine or not combine attendance in multiple groups.
- Added attended count and support for lava logic to hide the card.

**New Settings:**

_Display LastName Buttons_, Display a row of buttons with the first letter of LastName buttons. Default: Yes

_Allow Adding Person_, Should block support adding new people as attendees?

_Combine Group Attendance_, Should the block combine multiple group attendance to each person?

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added LastName buttons to jump down in long lists.
- Added ability to add an attendee to specific occurrence for a specific group.
- Added new setting to combine or not combine attendance in multiple groups.
- Added attended count and support for lava logic to hide the card.

---------

### Requested By

##### Who reported, requested, or paid for the change?

ADA

---------

### Screenshots

##### Does this update or add options to the block UI?

![image](https://github.com/user-attachments/assets/4f53c2c0-0075-44f4-ae10-1ec50651dcb0)

![image](https://github.com/user-attachments/assets/304a7416-1abd-432f-b3e0-470dc4adc325)

![image](https://github.com/user-attachments/assets/49f094db-504b-434e-89d6-20b86f95be4b)

---------

### Change Log

##### What files does it affect?

- Groups/GroupAttendanceMulti.ascx
- Groups/GroupAttendanceMulti.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
