### PR TITLE
Group Finder Bugs with "Single Select" Day of Week filter

### DIFF
--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -20,7 +20,7 @@
 //
 // Modification (including but not limited to):
 // * Added ability to set default location so when address is enabled a campus can be selected and results auto load.
-// * Added single select setting so that multiselect filters will be a drop down.
+// * Added single select setting so that multiselect campus filter can be a drop down.
 // * Added ability to set filters by url param
 // * Added an override setting for PersonGuid mode that enables search options
 // * Added postal code search capability
@@ -35,7 +35,7 @@
 // * Added Auto Load Filter capability on value selection
 // * Added ability to sort how filters are displayed
 // * Added ability to load Group/Sign Up Opportunities into finder
-// Package Version 1.8.2
+// Package Version 1.8.3
 // </notice>
 //
 using System;

--- a/Groups/GroupFinder.ascx.cs
+++ b/Groups/GroupFinder.ascx.cs
@@ -1035,7 +1035,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 var group = new GroupService( rockContext ).Get( e.RowKeyId );
                 if ( group != null )
                 {
-                    _urlParms.Add( "GroupGuid", group.Guid.ToString() );
+                    _urlParms.AddOrReplace( "GroupGuid", group.Guid.ToString() );
                     if ( !NavigateToLinkedPage( AttributeKey.RegisterPage, _urlParms ) )
                     {
                         ShowResults();
@@ -1591,6 +1591,10 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             {
                 var control = FieldTypeCache.Get( Rock.SystemGuid.FieldType.DAY_OF_WEEK ).Field.FilterControl( null, "filter_dow", false, Rock.Reporting.FilterMode.SimpleFilter );
                 string dayOfWeekLabel = GetAttributeValue( AttributeKey.DayOfWeekLabel );
+                if ( _autoPostback )
+                {
+                    AddAutoPostback( control );
+                }
                 AddFilterControl( control, dayOfWeekLabel, "", "filter_dow" );
             }
 
@@ -1598,6 +1602,10 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
             {
                 var control = FieldTypeCache.Get( Rock.SystemGuid.FieldType.TIME ).Field.FilterControl( null, "filter_time", false, Rock.Reporting.FilterMode.SimpleFilter );
                 string timeOfDayLabel = GetAttributeValue( AttributeKey.TimeOfDayLabel );
+                if ( _autoPostback )
+                {
+                    AddAutoPostback( control );
+                }
                 AddFilterControl( control, timeOfDayLabel, "", "filter_time" );
             }
 
@@ -2053,7 +2061,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     }
                     else
                     {
-                        _filterValues.Add( "FilterDows", dowsFilterControl.SelectedValuesAsInt.AsDelimited( "^" ) );
+                        _filterValues.AddOrReplace( "FilterDows", dowsFilterControl.SelectedValuesAsInt.AsDelimited( "^" ) );
                     }
                     groupQry = groupQry.Where( g =>
                         ( g.Schedule.WeeklyDayOfWeek.HasValue && dows.Contains( g.Schedule.WeeklyDayOfWeek.Value ) ) ||
@@ -2075,7 +2083,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                 //var expression = field.PropertyFilterExpression( null, filterValues, schedulePropertyExpression, "WeeklyDayOfWeek", typeof( DayOfWeek? ) );
                 //groupQry = groupQry.Where( groupParameterExpression, expression, null );
                 //Commented out property filter to have a custom DOW filter for iCalendarContent search.
-                _filterValues.Add( "FilterDow", filterValues.AsDelimited( "^" ) );
+                _filterValues.AddOrReplace( "FilterDow", filterValues.AsDelimited( "^" ) );
 
                 string formattedValue = string.Empty;
                 string searchStr = string.Empty;
@@ -2674,7 +2682,7 @@ namespace RockWeb.Plugins.rocks_kfs.Groups
                     {
                         var field = FieldTypeCache.Get( Rock.SystemGuid.FieldType.DAY_OF_WEEK ).Field;
                         var filterValues = field.GetFilterValues( dowFilterControl, null, Rock.Reporting.FilterMode.SimpleFilter );
-                        _filterValues.Add( "FilterDow", filterValues.AsDelimited( "^" ) );
+                        _filterValues.AddOrReplace( "FilterDow", filterValues.AsDelimited( "^" ) );
 
                         if ( filterValues.Count > 1 )
                         {


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Fixed block generating an exception when using a single-select day of week filter
- Also found that Auto Filter was not working for single-select day of week and the time filter.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed block generating an exception when using a single-select day of week filter
- Fixed Auto Filter for single-select day of week and the time filter.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Groups/GroupFinder.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
