### PR TITLE
Multi Group Attendance Bug

### DIFF
--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -649,7 +649,7 @@ namespace Plugins.rocks_kfs.Groups
                         {
                             var scheduleId = group.ScheduleId;
                             AttendanceOccurrence occurrence = null;
-                            var locationId = group.GroupLocations.FirstOrDefault()?.Id;
+                            var locationId = group.GroupLocations.FirstOrDefault()?.LocationId;
 
                             var occurrenceKey = $"{group.Id}_{scheduleId}_{locationId}";
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Using improper GroupLocation.Id instead of GroupLocation.LocationId for AttendanceOccurrence

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed issue where wrong location would get attached to occurrence.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Groups/GroupAttendanceMulti.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
