### PR TITLE
Eventbrite Webhook Update

### DIFF
--- a/Eventbrite/Sync.ashx
+++ b/Eventbrite/Sync.ashx
@@ -69,6 +69,7 @@ namespace RockWeb.Plugins.rocks_kfs.Eventbrite
 
             switch ( eventbriteData.Config.Action )
             {
+                case "attendee.updated":
                 case "attendee.checked_in":
                 case "barcode.checked_in":
                     // api_url example: https://www.eventbriteapi.com/v3/events/113027799190/attendees/1955015294/


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Add attendee.updated back to webhook support, due to possible intermediate mode between "Info Requested" and actually entering attendee information info would only be added with this webhook call.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed webhook not firing when attendee info was entered as a separate part of the registration.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

Eventbrite/Sync.ashx

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Documentation needs to be updated to reflect that you need to choose `attendee.updated` as part of the webhook setup.
