### PR TITLE
Multi Group attendance updates

### DIFF
--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -94,6 +94,7 @@
                     </asp:Panel>
                     <asp:Panel ID="pnlOther" runat="server" class="col-sm-6">
                         <Rock:RockLiteral ID="lSchedule" runat="server" Label="Schedule(s)" />
+                        <Rock:SchedulePicker ID="spSchedule" runat="server" Label="Schedule" ShowOnlyPublic="false" />
                     </asp:Panel>
                 </div>
                 <div class="row mb-3">

--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -102,7 +102,7 @@
                         <strong><asp:Literal ID="lCount" runat="server" /></strong> Attended
                     </asp:Panel>
                     <asp:Panel ID="pnlSearch" runat="server" CssClass="col-xs-12 pb-2 pb-sm-0 col-sm-5 col-md-5 col-sm-pull-3 col-md-pull-2">
-                        <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search"></Rock:RockTextBox>
+                        <Rock:RockTextBox ID="tbSearch" runat="server" OnTextChanged="tbSearch_TextChanged" Placeholder="Search" ToolTip="Enter a last name or a first name/last name combination. Use a comma after the name to search by first name only."></Rock:RockTextBox>
                     </asp:Panel>
                     <asp:Panel ID="pnlAddPerson" runat="server" CssClass="col-xs-12 col-sm-4 col-md-5 col-sm-pull-3 col-md-pull-2">
                         <Rock:RockDropDownList ID="ddlAddPersonGroup" runat="server" OnSelectedIndexChanged="ddlAddPersonGroup_SelectedIndexChanged" AutoPostBack="true"></Rock:RockDropDownList>

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -75,62 +75,62 @@ namespace Plugins.rocks_kfs.Groups
             JOIN GroupType gt ON gt.Id = gtr.GroupTypeId
             ORDER BY gt.[Name], gtr.[Order]",
         IsRequired = false,
-        Order = 1,
+        Order = 2,
         Key = AttributeKey.GroupTypeRolesToDisplay )]
 
     [LavaField( "Attendee Lava Template",
         Description = "Lava template used to customize appearance of individual attendee selectors.",
         IsRequired = true,
         DefaultValue = DefaultValue.AttendeeLavaTemplate,
-        Order = 2,
+        Order = 3,
         Key = AttributeKey.AttendeeLavaTemplate )]
 
     [TextField( "Checkbox Column Class",
         Description = "The Bootstrap 3 CSS classes to use for column width on various screen sizes. Default: col-xs-12 col-sm-6 col-md-3 col-lg-2",
         DefaultValue = "col-xs-12 col-sm-6 col-md-3 col-lg-2",
-        Order = 3,
+        Order = 4,
         Key = AttributeKey.CheckboxColumnClass )]
 
     [BooleanField( "Display Group Names",
         Description = "Display the group names after the block name in the panel title. Default: Yes",
         DefaultBooleanValue = true,
-        Order = 4,
+        Order = 5,
         Key = AttributeKey.DisplayGroupNames )]
 
     [BooleanField( "Allow Groups from Page Parameter",
         Description = "Allow GroupId's to be passed in via Page Parameter 'Groups' as a comma separated list. The current user must have permission to the groups for members to display. Default: No",
         DefaultBooleanValue = false,
-        Order = 5,
+        Order = 6,
         Key = AttributeKey.AllowGroupsPageParameter )]
 
     [LavaField( "Intro Lava Template",
         Description = "Lava template used to display instructions or group information.",
         IsRequired = false,
         DefaultValue = DefaultValue.IntroLavaTemplate,
-        Order = 6,
+        Order = 7,
         Key = AttributeKey.IntroLavaTemplate )]
 
     [BooleanField( "Display LastName buttons",
         Description = "Display a row of buttons with the first letter of LastName buttons. Default: Yes",
         DefaultBooleanValue = true,
-        Order = 7,
+        Order = 8,
         Key = AttributeKey.DisplayLastNameButtons )]
 
     [BooleanField( "Allow Adding Person",
         Description = "Should block support adding new people as attendees?",
         DefaultBooleanValue = false,
-        Order = 8,
+        Order = 9,
         Key = AttributeKey.AllowAddingPerson )]
 
     [BooleanField( "Combine Group Attendance",
         Description = "Should the block display only one record per person? This will result in a group attendance for that person in each associated group.",
         DefaultBooleanValue = false,
-        Order = 9,
+        Order = 10,
         Key = AttributeKey.CombineGroupAttendance )]
 
     [CustomDropdownListField( "Schedule Selection Mode",
         Description = "Should the block display the schedule picker?",
-        ListSource = "Hide,Always allow editing,Only if Single Schedule/Group",
+        ListSource = "Hide,Always allow editing,Only if single schedule/group",
         DefaultValue = "Hide",
         Key = AttributeKey.ScheduleSelectionMode,
         Order = 11 )]

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -650,7 +650,7 @@ namespace Plugins.rocks_kfs.Groups
                 _attendees.AddRange( attended.Where( at => !_attendees.Any( a => a.PersonId == at.PersonId && at.Groups.Any( g => a.Groups.Contains( g ) ) ) ) );
             }
 
-            var searchParts = tbSearch.Text.ToLower().SplitDelimitedValues();
+            var searchParts = tbSearch.Text.ToLower().Split( new char[] { ',', ' ', ';', '.' }, StringSplitOptions.None );
             _attendees = _attendees.Where( a => tbSearch.Text.IsNullOrWhiteSpace() ||
                                           ( searchParts.Length == 1 && a.LastName.ToLower().StartsWith( searchParts[0] ) ) ||
                                           ( searchParts.Length > 1 && ( a.FirstName.ToLower().StartsWith( searchParts[0] ) ||

--- a/Groups/GroupAttendanceMulti.ascx.cs
+++ b/Groups/GroupAttendanceMulti.ascx.cs
@@ -651,17 +651,28 @@ namespace Plugins.rocks_kfs.Groups
                 _attendees.AddRange( attended.Where( at => !_attendees.Any( a => a.PersonId == at.PersonId && at.Groups.Any( g => a.Groups.Contains( g ) ) ) ) );
             }
 
-            var searchParts = tbSearch.Text.ToLower().Split( new char[] { ',', ' ', ';', '.' }, StringSplitOptions.None );
+            var searchParts = tbSearch.Text.ToLower().SplitDelimitedValues();
             _attendees = _attendees.Where( a => tbSearch.Text.IsNullOrWhiteSpace() ||
-                                          ( searchParts.Length == 1 && a.LastName.ToLower().StartsWith( searchParts[0] ) ) ||
-                                          ( searchParts.Length > 1 && ( a.FirstName.ToLower().StartsWith( searchParts[0] ) ||
-                                                                        a.NickName.ToLower().StartsWith( searchParts[0] )
-                                                                      ) && a.LastName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
-                                          ) ||
-                                          ( searchParts.Length > 1 && ( a.FirstName.ToLower().StartsWith( searchParts[searchParts.Length - 1] ) ||
-                                                                        a.NickName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
-                                                                      ) && a.LastName.ToLower().StartsWith( searchParts[0] )
-                                          )
+                                                searchParts.Length == 1 &&
+                                                ( a.FirstName.ToLower().StartsWith( searchParts[0] ) ||
+                                                  a.NickName.ToLower().StartsWith( searchParts[0] ) ||
+                                                  a.LastName.ToLower().StartsWith( searchParts[0] )
+                                                ) ||
+                                                searchParts.Length > 1 &&
+                                                (
+                                                    (
+                                                        ( a.FirstName.ToLower().StartsWith( searchParts[0] ) ||
+                                                          a.NickName.ToLower().StartsWith( searchParts[0] )
+                                                        ) &&
+                                                        a.LastName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
+                                                    ) ||
+                                                    (
+                                                        ( a.FirstName.ToLower().StartsWith( searchParts[searchParts.Length - 1] ) ||
+                                                          a.NickName.ToLower().StartsWith( searchParts[searchParts.Length - 1] )
+                                                        ) &&
+                                                        a.LastName.ToLower().StartsWith( searchParts[0] )
+                                                    )
+                                                )
                                     )
                                     .OrderBy( a => a.LastName )
                                     .ThenBy( a => a.FirstName )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added ability to filter by Group Role with new setting.
- Added ability to select a schedule to save on attendance.
- Fixed search to be able to search First Name/Nickname only.

**New Settings:**

- _Group Type Roles to Display_, Select the group type role(s) to display in this attendance block. You may also pass in a comma separated list of GroupTypeRoleId's via a PageParameter 'GroupRoles'.
- _Schedule Selection Mode_, Should the block display the schedule picker?

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added ability to filter by Group Role with new setting.
- Added ability to select a schedule to save on attendance.
- Fixed search to be able to search First Name/Nickname only.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Ada

---------

### Screenshots

##### Does this update or add options to the block UI?

Schedule Picker and Example of First Name search:   
![image](https://github.com/user-attachments/assets/7f60f81a-afbc-43c1-97de-54fcf1a65cb2)

![image](https://github.com/user-attachments/assets/060d717a-63c5-4136-9e7d-e3abce678aaa)

---------

### Change Log

##### What files does it affect?

- Groups/GroupAttendanceMulti.ascx
- Groups/GroupAttendanceMulti.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
