### PR TITLE
Bug Fixes for Edit Profile and Communication List Subscribe

### DIFF
--- a/Cms/ProfileBioEdit.ascx.cs
+++ b/Cms/ProfileBioEdit.ascx.cs
@@ -794,8 +794,8 @@ namespace RockWeb.Plugins.rocks_kfs.Cms
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbAddFamilyMember_Click( object sender, EventArgs e )
         {
-            var pnlFamilyMemberBody = pnlProfilePanels.FindControl( "pnlFamilyMemberBody" );
-            if ( pnlFamilyMemberBody != null )
+            var pnlFamilyMemberWidgets = pnlProfilePanels.FindControl( "pnlFamilyMemberWidgets" );
+            if ( pnlFamilyMemberWidgets != null )
             {
                 var lastPersonId = FamilyMembers.OrderByDescending( fm => fm.PersonId ).Select( fm => fm.PersonId ).LastOrDefault();
                 if ( lastPersonId > 0 )
@@ -814,7 +814,9 @@ namespace RockWeb.Plugins.rocks_kfs.Cms
 
                 FamilyMembers.Add( newFamilyMember );
 
-                AddFamilyMember( pnlFamilyMemberBody, newFamilyMember, true );
+                toggleFamilyMemberFooter( pnlProfilePanels );
+
+                AddFamilyMember( pnlFamilyMemberWidgets, newFamilyMember, true );
             }
         }
 
@@ -826,13 +828,15 @@ namespace RockWeb.Plugins.rocks_kfs.Cms
         private void pwFamilyMember_DeleteClick( object sender, EventArgs e )
         {
             PanelWidget panelWidget = sender as PanelWidget;
-            var pnlFamilyMemberBody = pnlProfilePanels.FindControl( "pnlFamilyMemberBody" );
-            if ( panelWidget != null && pnlFamilyMemberBody != null )
+            var pnlFamilyMemberWidgets = pnlProfilePanels.FindControl( "pnlFamilyMemberWidgets" );
+            if ( panelWidget != null && pnlFamilyMemberWidgets != null )
             {
                 var personId = panelWidget.ID.Replace( "pwFamilyMember_", string.Empty ).AsInteger();
-                pnlFamilyMemberBody.Controls.Remove( panelWidget );
                 var familyMember = FamilyMembers.First( a => a.PersonId == personId );
                 FamilyMembers.Remove( familyMember );
+                pnlFamilyMemberWidgets.Controls.Remove( panelWidget );
+
+                toggleFamilyMemberFooter( pnlProfilePanels );
             }
         }
 
@@ -1178,6 +1182,8 @@ namespace RockWeb.Plugins.rocks_kfs.Cms
                     var pnlFamilyMemberWidgets = new Panel { ID = "pnlFamilyMemberWidgets" };
                     pnlFamilyMemberBody.Controls.Add( pnlFamilyMemberWidgets );
 
+                    toggleFamilyMemberFooter( pnlFamilyMember );
+
                     foreach ( var fm in FamilyMembers )
                     {
                         AddFamilyMember( pnlFamilyMemberWidgets, fm );
@@ -1186,6 +1192,21 @@ namespace RockWeb.Plugins.rocks_kfs.Cms
             }
             #endregion
 
+        }
+
+        private void toggleFamilyMemberFooter( Panel pnlFamilyMember )
+        {
+            var pnlFamilyMemberBody = pnlFamilyMember.FindControl( "pnlFamilyMemberBody" );
+            var pnlFamilyMemberFooter = pnlFamilyMember.FindControl( "pnlFamilyMemberFooter" );
+
+            if ( pnlFamilyMemberBody != null )
+            {
+                pnlFamilyMemberBody.Visible = FamilyMembers.Any();
+            }
+            if ( pnlFamilyMemberFooter != null )
+            {
+                pnlFamilyMemberFooter.Visible = FamilyMembers.Any();
+            }
         }
 
         private void AddFamilyMember( Control pnlFamilyMemberBody, PersonFamilyMember fm, bool expanded = false )

--- a/Communication/CommunicationListSubscribe.ascx
+++ b/Communication/CommunicationListSubscribe.ascx
@@ -33,14 +33,14 @@
                                         <asp:Repeater ID="rptCommunicationLists" runat="server" OnItemDataBound="rptCommunicationLists_ItemDataBound">
                                             <ItemTemplate>
                                                 <div class="row">
-                                                    <div class="col-xs-6">
+                                                    <asp:Panel ID="col1" runat="server" CssClass="col-xs-6">
                                                         <asp:HiddenField ID="hfGroupId" runat="server" />
                                                         <Rock:RockCheckBox ID="cbCommunicationListIsSubscribed" runat="server" AutoPostBack="true" OnCheckedChanged="cbCommunicationListIsSubscribed_CheckedChanged" />
                                                         <Rock:NotificationBox ID="nbGroupNotification" runat="server" Visible="false" />
-                                                    </div>
-                                                    <div class="col-xs-6">
+                                                    </asp:Panel>
+                                                    <asp:Panel ID="col2" runat="server" CssClass="col-xs-6">
                                                         <Rock:Toggle ID="tglCommunicationPreference" runat="server" OnText="Email" OffText="SMS" ButtonSizeCssClass="btn-xs" OnCssClass="btn-info" OffCssClass="btn-info" OnCheckedChanged="tglCommunicationPreference_CheckedChanged" />
-                                                    </div>
+                                                    </asp:Panel>
                                                 </div>
                                             </ItemTemplate>
                                         </asp:Repeater>

--- a/Communication/CommunicationListSubscribe.ascx.cs
+++ b/Communication/CommunicationListSubscribe.ascx.cs
@@ -80,6 +80,12 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
         IsRequired = false,
         Key = AttributeKey.CommunicationListCategoriesExpanded,
         Order = 4 )]
+    [TextField(
+        "List Repeater CSS Class",
+        Description = "CSS Class to use on the category list repeater.",
+        DefaultValue = "row",
+        Key = AttributeKey.ListRepeaterCSSClass,
+        Order = 5 )]
 
     #endregion Block Attributes
 
@@ -96,6 +102,7 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             public const string ShowMediumPreference = "ShowMediumPreference";
             public const string ShowCommunicationListCategories = "ShowCommunicationListCategories";
             public const string CommunicationListCategoriesExpanded = "CommunicationListCategoriesOpen";
+            public const string ListRepeaterCSSClass = "ListRepeaterCSSClass";
         }
 
         #endregion Attribute Keys
@@ -179,6 +186,13 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
             {
                 var pwCategoryPanel = e.Item.FindControl( "pwCategoryPanel" ) as PanelWidget;
                 var openCategoryGuids = this.GetAttributeValue( AttributeKey.CommunicationListCategoriesExpanded ).SplitDelimitedValues().AsGuidList();
+                var listRepeaterCssClass = GetAttributeValue( AttributeKey.ListRepeaterCSSClass );
+
+                var pnlListRepeaterParent = e.Item.FindControl( "pnlListRepeaterParent" ) as Panel;
+                if ( pnlListRepeaterParent != null )
+                {
+                    pnlListRepeaterParent.CssClass = listRepeaterCssClass;
+                }
 
                 pwCategoryPanel.Expanded = openCategoryGuids.Contains( category.Guid );
                 pwCategoryPanel.Title = category.Name;
@@ -262,6 +276,21 @@ namespace RockWeb.Plugins.rocks_kfs.Communication
                 var tglCommunicationPreference = e.Item.FindControl( "tglCommunicationPreference" ) as Toggle;
                 tglCommunicationPreference.Checked = communicationType == CommunicationType.Email;
                 tglCommunicationPreference.Visible = showMediumPreference;
+
+                if ( !tglCommunicationPreference.Visible )
+                {
+                    var tglCommunicationPreferenceParent = tglCommunicationPreference.Parent as WebControl;
+                    if ( tglCommunicationPreferenceParent != null )
+                    {
+                        tglCommunicationPreferenceParent.Visible = false;
+                    }
+
+                    var hfGroupIdParent = hfGroupId.Parent as WebControl;
+                    if ( hfGroupIdParent != null )
+                    {
+                        hfGroupIdParent.CssClass = "col-xs-12";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Fixed two bugs with new Edit Profile block, delete new family member was not actually working and save changes button was still showing even if you had no family members.
- Updated Communication List Subscribe with a new CSS Class setting to control display a bit better.

**New Settings:**

_List Repeater CSS Class_, CSS Class to use on the category list repeater.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed two bugs with new Edit Profile block, delete new family member was not actually working and save changes button was still showing even if you had no family members.
- Updated Communication List Subscribe with a new CSS Class setting to control display a bit better.

---------

### Requested By

##### Who reported, requested, or paid for the change?

VWC

---------

### Screenshots

##### Does this update or add options to the block UI?

No more save button when no family members:   
![image](https://github.com/user-attachments/assets/c26257bf-5950-4642-9c59-199c5033673b)

Ability to have multiple columns using CSS instead of each one forced to a row:   
![image](https://github.com/user-attachments/assets/0a8454f7-eeb9-4b2c-9043-d00e695f86b2)

Default display:   
![image](https://github.com/user-attachments/assets/909368a9-70e9-4e86-ae21-bd4113eb3751)

---------

### Change Log

##### What files does it affect?

- Cms/ProfileBioEdit.ascx.cs
- Communication/CommunicationListSubscribe.ascx
- Communication/CommunicationListSubscribe.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
