### PR TITLE
Multi Group Attendance - Group Schedule Support

### DIFF
--- a/Groups/GroupAttendanceMulti.ascx
+++ b/Groups/GroupAttendanceMulti.ascx
@@ -95,6 +95,7 @@
                     <asp:Panel ID="pnlOther" runat="server" class="col-sm-6">
                         <Rock:RockLiteral ID="lSchedule" runat="server" Label="Schedule(s)" />
                         <Rock:SchedulePicker ID="spSchedule" runat="server" Label="Schedule" ShowOnlyPublic="false" />
+                        <Rock:RockDropDownList ID="ddlSchedule" runat="server" Label="Schedule" OnSelectedIndexChanged="ddlSchedule_SelectedIndexChanged" AutoPostBack="true" EnhanceForLongLists="true" />
                     </asp:Panel>
                 </div>
                 <div class="row mb-3">


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Added additional schedule selection mode of "From Group Schedules"
- Added ability to narrow down schedules to what is already set on the selected Groups. 
- Now with specific selectable schedules editing can be narrowed down to individual schedule attendance as well.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added additional schedule selection mode of "From Group Schedules"

---------

### Requested By

##### Who reported, requested, or paid for the change?

ADA

---------

### Screenshots

##### Does this update or add options to the block UI?

<img width="1731" height="364" alt="image" src="https://github.com/user-attachments/assets/55ba1365-df63-4b1c-86b2-b94aa6062659" />

<img width="2342" height="759" alt="image" src="https://github.com/user-attachments/assets/2db34502-ea4c-4c43-a181-9aac321329b8" />

---------

### Change Log

##### What files does it affect?

- Groups/GroupAttendanceMulti.ascx
- Groups/GroupAttendanceMulti.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
