### PR TITLE
Steps to Care Bug Fix

### DIFF
--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -683,7 +683,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                             }
                             careNeed.ChildNeeds.Add( copyNeed );
                             changes.AddChange( History.HistoryVerb.Add, History.HistoryChangeType.Record, $"Child Care Need for {fm.Person.FullName}" );
-                            fmChangesLists.TryAdd( fm.Person.PrimaryAliasId, fmChanges );
+                            fmChangesLists.AddOrIgnore( fm.Person.PrimaryAliasId, fmChanges );
                         }
                         childNeedsCreated = true;
                     }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

We are not ready for TryAdd yet, still supporting 16.3-16.5 which does not have that... Switch to AddOrReplace like other places in code. Older and non deprecated method.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed an incorrect new method being added while still supporting 16.3+

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty/Support

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

StepsToCare/CareEntry.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
