### PR TITLE
Steps to Care ToolTip on iOS

### DIFF
--- a/StepsToCare/CareDashboard.ascx
+++ b/StepsToCare/CareDashboard.ascx
@@ -45,11 +45,11 @@
         text-align: center;
     }
 
-    .js-person-popover-stepstocare + .popover {
+    .popover, .popover-stepstocare {
         max-width: 100%;
     }
 
-        .js-person-popover-stepstocare + .popover .popover-content .person-image {
+        .js-person-popover-stepstocare + .popover .popover-content .person-image, .popover-stepstocare .person-image {
             float: left;
             width: 70px;
             height: 70px;
@@ -59,18 +59,36 @@
             border: 1px solid #dfe0e1;
         }
 
-        .js-person-popover-stepstocare + .popover .popover-content .contents {
+        .js-person-popover-stepstocare + .popover .popover-content .contents, .popover-stepstocare .contents {
             float: left;
-            width: calc(100% - 78px);
+            /*width: calc(100% - 78px);*/
         }
 
-        .js-person-popover-stepstocare + .popover .popover-content .email {
+        .js-person-popover-stepstocare + .popover .popover-content .email, .popover-stepstocare .email {
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;
             width: 100%;
             display: inline-block;
         }
+        
+    @media (max-width: 480px) {
+        .js-person-popover-stepstocare + .popover .popover-content .person-image, .popover-stepstocare .person-image {
+            float: none;
+            width: 100%;
+            height: 150px;
+            margin-right: 0px;
+            margin-bottom: 8px;
+            background-position: 50%;
+            background-size: contain;
+            background-repeat: no-repeat;
+            border: 0;
+        }
+        .js-person-popover-stepstocare + .popover .popover-content .contents, .popover-stepstocare .contents {
+            float: none;
+            width: 100%;
+        }
+    }
 
     .hasParentNeed {
         background-color: #ececec !important;
@@ -289,6 +307,7 @@
                     $('.js-person-popover-stepstocare').popover({
                         placement: 'right',
                         trigger: 'manual',
+                        container: 'body',
                         sanitize: false,
                         delay: 500,
                         html: true,
@@ -302,7 +321,9 @@
                                 async: false
                             }).responseText;
 
-                            return result.replace(/^"/i, '').replace(/"$/i, '').replace(/\\"/ig, '"').replace(/<span class=['"]email['"]>(.*)<\/span>/ig, '<a href="/Communication?person=' + $(this).attr('personid') + '" class="email">$1</a>');
+                            result = '<div class=\'popover-stepstocare\'>' + result.replace(/^"/i, '').replace(/"$/i, '') + '</div>';
+
+                            return result.replace(/\\"/ig, '"').replace(/&width=65/ig, '&width=150').replace(/<span class=['"]email['"]>(.*)<\/span>/ig, '<a href="/Communication?person=' + $(this).attr('personid') + '" class="email">$1</a>');
 
                         }
                     }).on('mouseenter', function () {

--- a/StepsToCare/CareDashboard.ascx.cs
+++ b/StepsToCare/CareDashboard.ascx.cs
@@ -422,7 +422,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
 {% for category in Categories %}
     <span class=""badge rounded-0 p-2 mb-2"" style=""background-color: {{ category | Attribute:'Color' }}"">{{ category.Value }}</span>
 {% endfor %}
-<br><span class=""badge rounded-0 p-2 mb-2 text-color"" style=""background-color: oldlace"">Assigned to You</span>
+<br><span class=""badge rounded-0 p-2 mb-2 assigned text-color"">Assigned to You</span>
 </div>";
 
         private const string QuickNoteStatusTemplateDefaultValue = @"<div class=""pull-right""><span class=""label mr-2"" style=""background-color: {{ CareNeed.Category | Attribute:'Color' }}"">{{ CareNeed.Category.Value }}</span><span class=""{{ CareNeed.Status | Attribute:'CssClass' }}"">{{ CareNeed.Status.Value }}</span></div>

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -1514,7 +1514,12 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 var category = DefinedValueCache.Get( categoryId.Value );
                 var categoryFollowUpAfter = category.GetAttributeValue( "FollowUpAfter" ).AsIntegerOrNull();
                 var categoryTimesToRepeat = category.GetAttributeValue( "TimesToRepeat" ).AsIntegerOrNull();
-                if ( categoryFollowUpAfter.HasValue && categoryFollowUpAfter > 0 )
+                CareNeed careNeed = null;
+                if ( !needId.Equals( 0 ) )
+                {
+                    careNeed = new CareNeedService( new RockContext() ).Get( needId );
+                }
+                if ( categoryFollowUpAfter.HasValue && categoryFollowUpAfter > 0 && ( careNeed == null || careNeed != null && categoryId.Value != careNeed.CategoryValueId ) )
                 {
                     cbCustomFollowUp.Checked = true;
                     numbRepeatDays.IntegerValue = categoryFollowUpAfter;

--- a/StepsToCare/CareEntry.ascx.cs
+++ b/StepsToCare/CareEntry.ascx.cs
@@ -1519,7 +1519,7 @@ namespace RockWeb.Plugins.rocks_kfs.StepsToCare
                 {
                     careNeed = new CareNeedService( new RockContext() ).Get( needId );
                 }
-                if ( categoryFollowUpAfter.HasValue && categoryFollowUpAfter > 0 && ( careNeed == null || careNeed != null && categoryId.Value != careNeed.CategoryValueId ) )
+                if ( categoryFollowUpAfter.HasValue && categoryFollowUpAfter > 0 && ( careNeed == null || categoryId.Value != careNeed.CategoryValueId ) )
                 {
                     cbCustomFollowUp.Checked = true;
                     numbRepeatDays.IntegerValue = categoryFollowUpAfter;


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Fix for iOS popover issues. Has to be outside the relative/overflow table otherwise it gets cut off. 
- Static assigned class was not being added to the default lava for categories, now it is.
- Fixed an issue where the default "Follow Up After" days set on a category would override any custom value on specific need.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fix for iOS popover getting cutoff in some instances.
- Fixed an issue where the default "Follow Up After" days set on a category would override any custom value on specific need.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

Doesn't really highlight the issue it was having on the other client, but I forgot to take a screenshot before fixing it. Before style changes:   
<img width="248" height="313" alt="image" src="https://github.com/user-attachments/assets/9786d2bf-6f8e-4023-b856-999bf3b52b55" />

After:   
<img width="284" height="389" alt="image" src="https://github.com/user-attachments/assets/53fc200d-4c90-4b3b-90b3-effb2023022e" />

---------

### Change Log

##### What files does it affect?

- StepsToCare/CareDashboard.ascx
- StepsToCare/CareDashboard.ascx.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
